### PR TITLE
ansible_role_parser.py - appending '\n' to footer.

### DIFF
--- a/ansible_role_parser.py
+++ b/ansible_role_parser.py
@@ -118,7 +118,7 @@ class LSRFileTransformerBase(object):
             self.header = ""
         match = re.search(LSRFileTransformerBase.FOOTER_RE, buf)
         if match:
-            self.footer = match.group(1)
+            self.footer = match.group(1) + "\n"
         else:
             self.footer = ""
         self.ruamel_yaml.default_flow_style = False


### PR DESCRIPTION
Fixing yamllint new-line-at-end-of-file.
  error  no new line character at the end of file (new-line-at-end-of-file)