### PR TITLE
RHELPLAN-42929 - Collections - script - add CI testing for collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ This is a tool to convert a linux-system-role style role to the collections form
 ## usage
 ```
 lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
-                       [--dest-path DEST_PATH] [--src-path SRC_PATH] [--role ROLE]
-                       [--replace-dot REPLACE_DOT] [--subrole-prefix SUBROLE_PREFIX]
+                       [--dest-path DEST_PATH] [--tests-dest-path TESTS_DEST_PATH]
+                       [--src-path SRC_PATH] [--role ROLE] [--replace-dot REPLACE_DOT]
+                       [--subrole-prefix SUBROLE_PREFIX]
 ```
 
 ### optional arguments
@@ -147,6 +148,10 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
 --dest-path DEST_PATH
                      Path to parent of collection where role should be migrated;
                      default to ${HOME}/.ansible/collections
+--tests-dest-path TESTS_DEST_PATH
+                     Path to parent of tests directory in which rolename directory is
+                     created and test scripts are copied to the directory; default to
+                     DEST_PATH/NAMESPACE/COLLECTION
 --src-path SRC_PATH  Path to the parent directory of the source role;
                      default to ${HOME}/linux-system-roles
 --role ROLE          Role to convert to collection
@@ -212,10 +217,10 @@ python lsr_role2collection.py --role myrole --namespace community --collection t
 ```
 
 ## Example 3
-Convert a role myrole located in a custom src-path to a custom dest-path
+Convert a role myrole located in a custom src-path to a custom dest-path and a custom tests-dest-path
 
 Source role path is /path/to/role_group/myrole.
 Destination collections path is /path/to/collections.
 ```
-python lsr_role2collection.py --src-path /path/to/role_group --dest-path /path/to/collections --role myrole
+python lsr_role2collection.py --src-path /path/to/role_group --dest-path /path/to/collections --tests-dest-path /path/to/test_dir --role myrole
 ```

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -877,6 +877,12 @@ def main():
         help="Path to parent of collection where role should be migrated; default to ${HOME}/.ansible/collections",
     )
     parser.add_argument(
+        "--tests-dest-path",
+        type=Path,
+        default=os.environ.get("COLLECTION_TESTS_DEST_PATH", None),
+        help="Path to parent of tests directory in which rolename directory is created and test scripts are copied to the directory; default to DEST_PATH/NAMESPACE/COLLECTION",  # noqa:E501
+    )
+    parser.add_argument(
         "--src-path",
         type=Path,
         default=os.environ.get("COLLECTION_SRC_PATH", HOME + "/linux-system-roles"),
@@ -924,6 +930,12 @@ def main():
     dest_path = Path.joinpath(
         top_dest_path, "ansible_collections/" + namespace + "/" + collection
     )
+    _tests_dest_path = args.tests_dest_path
+    if _tests_dest_path:
+        tests_dest_path = Path(_tests_dest_path)
+    else:
+        tests_dest_path = dest_path
+
     os.makedirs(dest_path, exist_ok=True)
 
     roles_dir = dest_path / "roles"
@@ -971,7 +983,7 @@ def main():
 
     copy_tree_with_replace(
         src_path,
-        dest_path,
+        tests_dest_path,
         role,
         TESTS,
         transformer_args,
@@ -1181,7 +1193,7 @@ def main():
                     # copy tests dir to dest_path/"tests"
                     copy_tree_with_replace(
                         sr,
-                        dest_path,
+                        tests_dest_path,
                         dr,
                         TESTS,
                         transformer_args,


### PR DESCRIPTION
For the preparation of the task, adding an option to specify the
tests path to copy.
```
  --tests-dest-path TESTS_DEST_PATH
          Path to parent of tests directory in which rolename directory
          is created and test scripts are copied to the directory;
          default to DEST_PATH/NAMESPACE/COLLECTION
```