### PR TITLE
Adjusting lsr_role2collection.py to the CI integration test env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ This is a tool to convert a linux-system-role style role to the collections form
 ```
 lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                        [--dest-path DEST_PATH] [--tests-dest-path TESTS_DEST_PATH]
-                       [--src-path SRC_PATH] [--role ROLE] [--replace-dot REPLACE_DOT]
-                       [--subrole-prefix SUBROLE_PREFIX]
+                       [--src-path SRC_PATH] [--src-owner SRC_OWNER] [--role ROLE]
+                       [--replace-dot REPLACE_DOT] [--subrole-prefix SUBROLE_PREFIX]
 ```
 
 ### optional arguments
@@ -154,6 +154,10 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                      DEST_PATH/NAMESPACE/COLLECTION
 --src-path SRC_PATH  Path to the parent directory of the source role;
                      default to ${HOME}/linux-system-roles
+--src-owner SRC_OWNER
+                     Owner of the role in github. If the parent directory name in SRC_PATH is
+                     not the github owner, may need to set to it, e.g., "linux-system-roles";
+                     default to the parent directory of SRC_PATH
 --role ROLE          Role to convert to collection
 --replace-dot REPLACE_DOT
                      If sub-role name contains dots, replace them with the specified
@@ -223,4 +227,13 @@ Source role path is /path/to/role_group/myrole.
 Destination collections path is /path/to/collections.
 ```
 python lsr_role2collection.py --src-path /path/to/role_group --dest-path /path/to/collections --tests-dest-path /path/to/test_dir --role myrole
+```
+
+## Example 4
+Convert a role myrole in a github owner "linux-system-roles" located in a custom src-path to a custom dest-path and a custom tests-dest-path
+
+Source role path is /path/to/role_group/myrole.
+Destination collections path is /path/to/collections.
+```
+python lsr_role2collection.py --src-path /path/to/role_group --dest-path /path/to/collections --tests-dest-path /path/to/test_dir --role myrole --src-owner linux-system-roles
 ```

--- a/tests/unit/test_lsr_role2collection.py
+++ b/tests/unit/test_lsr_role2collection.py
@@ -266,6 +266,7 @@ class LSRRole2Collection(unittest.TestCase):
             "subrole_prefix": "",
             "replace_dot": "_",
             "role_modules": set(),
+            "src_owner": "linux-system-roles",
         }
         copy_tree_with_replace(
             role_path, coll_path, rolename, MYTUPLE, transformer_args, isrole=True
@@ -278,12 +279,12 @@ class LSRRole2Collection(unittest.TestCase):
 
     def test_cleanup_symlinks(self):
         """test cleanup_symlinks"""
-
+        owner = "linux-system-roles"
         params = [
             {
                 "key": "roles",
                 "subkey": "-",
-                "value": "linux-system-roles",
+                "value": owner,
                 "delim": ".",
                 "subvalue": rolename,
             },
@@ -300,13 +301,13 @@ class LSRRole2Collection(unittest.TestCase):
         self.create_test_tree(
             test_path, test_yaml_str, params, ".yml", is_vertical=False
         )
-        link = "linux-system-roles." + rolename
+        link = owner + "." + rolename
         test_role_path = test_path / "roles"
-        # case 1. tests/roles/linux-system-roles.systemrole -> roles/systemrole
+        # case 1. tests/roles/owner.systemrole -> roles/systemrole
         self.create_test_link(test_role_path, link, role_path, True)
         cleanup_symlinks(test_path, rolename)
         self.check_test_link(test_role_path, False)
-        # case 2. tests/roles/linux-system-roles.systemrole -> roles/systemrole
+        # case 2. tests/roles/owner.systemrole -> roles/systemrole
         #         tests/roles/some_file
         self.create_test_link(test_role_path, link, role_path, True)
         self.create_test_tree(
@@ -316,7 +317,7 @@ class LSRRole2Collection(unittest.TestCase):
         self.check_test_link(test_role_path, True)
         self.check_test_link(test_role_path / link, False)
         shutil.rmtree(test_role_path)
-        # case 3. tests/roles/linux-system-roles.systemrole -> roles/systemrole
+        # case 3. tests/roles/owner.systemrole -> roles/systemrole
         #         tests/roles/some_symlinks
         self.create_test_link(test_role_path, link, role_path, True)
         extralink = "extralink"


### PR DESCRIPTION
- Renaming the main function to role2collection.
- In the src path, allow a role is located in the directory other than "linux-system-roles".
- Adding --src-owner to specify github owner, e.g., "linux-system-roles".