### PR TITLE
lsr_role2collection.py - trailing comments were not properly handled

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -381,7 +381,7 @@ DO_NOT_COPY = (
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY
 
 IMPORT_RE = re.compile(
-    br"(\bimport) (ansible\.module_utils\.)(\S+)(\S*)(\s+#.+|.*)$", flags=re.M
+    br"(\bimport) (ansible\.module_utils\.)(\S+)(.*)(\s+#.+|.*)$", flags=re.M
 )
 FROM_RE = re.compile(
     br"(\bfrom) (ansible\.module_utils\.?)(\S+)? import (\(*(?:\n|\r\n)?)(\S+)(\s+#.+|.*)$",

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -380,9 +380,11 @@ DO_NOT_COPY = (
 
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY
 
-IMPORT_RE = re.compile(br"(\bimport) (ansible\.module_utils\.)(\S+)(.*)$", flags=re.M)
+IMPORT_RE = re.compile(
+    br"(\bimport) (ansible\.module_utils\.)(\S+)(\S*)(\s+#.+|.*)$", flags=re.M
+)
 FROM_RE = re.compile(
-    br"(\bfrom) (ansible\.module_utils\.?)(\S+)? import (\(*(?:\n|\r\n)?)(.+)$",
+    br"(\bfrom) (ansible\.module_utils\.?)(\S+)? import (\(*(?:\n|\r\n)?)(\S+)(\s+#.+|.*)$",
     flags=re.M,
 )
 
@@ -660,27 +662,30 @@ def import_replace(match):
         if match.group(1) == b"import" and match.group(4) == b"":
             _additional_rewrites.append(parts)
             if src_module_path.exists() or Path(str(src_module_path) + ".py").exists():
-                return b"import ansible_collections.%s.%s.plugins.module_utils.%s" % (
+                return b"import ansible_collections.%s.%s.plugins.module_utils.%s%s" % (
                     bytes(_namespace, "utf-8"),
                     bytes(_collection, "utf-8"),
                     match_group3,
+                    match.group(5),
                 )
             else:
                 return (
-                    b"import ansible_collections.%s.%s.plugins.module_utils.%s as %s"
+                    b"import ansible_collections.%s.%s.plugins.module_utils.%s as %s%s"
                     % (
                         bytes(_namespace, "utf-8"),
                         bytes(_collection, "utf-8"),
                         match_group3,
                         parts[-1],
+                        match.group(5),
                     )
                 )
-        return b"%s ansible_collections.%s.%s.plugins.module_utils.%s%s" % (
+        return b"%s ansible_collections.%s.%s.plugins.module_utils.%s%s%s" % (
             match.group(1),
             bytes(_namespace, "utf-8"),
             bytes(_collection, "utf-8"),
             match_group3,
             match.group(4),
+            match.group(5),
         )
     return match.group(0)
 
@@ -763,7 +768,7 @@ def from_replace(match):
             or lfrom_file1.is_file()
         ):
             return (
-                b"%s ansible_collections.%s.%s.plugins.module_utils.%s import %s%s"
+                b"%s ansible_collections.%s.%s.plugins.module_utils.%s import %s%s%s"
                 % (
                     match.group(1),
                     bytes(_namespace, "utf-8"),
@@ -771,16 +776,18 @@ def from_replace(match):
                     match_group3,
                     match.group(4),
                     match.group(5),
+                    match.group(6),
                 )
             )
         else:
-            return b"%s ansible_collections.%s.%s.plugins.module_utils.%s.__init__ import %s%s" % (
+            return b"%s ansible_collections.%s.%s.plugins.module_utils.%s.__init__ import %s%s%s" % (
                 match.group(1),
                 bytes(_namespace, "utf-8"),
                 bytes(_collection, "utf-8"),
                 match_group3,
                 match.group(4),
                 match.group(5),
+                match.group(6),
             )
     if parts5 in _module_utils:
         from_file0, lfrom_file0, from_file1, lfrom_file1 = get_candidates(
@@ -793,25 +800,24 @@ def from_replace(match):
                 or lfrom_file0.is_file()
                 or lfrom_file1.is_file()
             ):
-                return (
-                    b"%s ansible_collections.%s.%s.plugins.module_utils.%s import %s%s"
-                    % (
-                        match.group(1),
-                        bytes(_namespace, "utf-8"),
-                        bytes(_collection, "utf-8"),
-                        match.group(3),
-                        match.group(4),
-                        match.group(5),
-                    )
-                )
-            else:
-                return b"%s ansible_collections.%s.%s.plugins.module_utils.%s.__init__ import %s%s" % (
+                return b"%s ansible_collections.%s.%s.plugins.module_utils.%s import %s%s%s" % (
                     match.group(1),
                     bytes(_namespace, "utf-8"),
                     bytes(_collection, "utf-8"),
                     match.group(3),
                     match.group(4),
                     match.group(5),
+                    match.group(6),
+                )
+            else:
+                return b"%s ansible_collections.%s.%s.plugins.module_utils.%s.__init__ import %s%s%s" % (
+                    match.group(1),
+                    bytes(_namespace, "utf-8"),
+                    bytes(_collection, "utf-8"),
+                    match.group(3),
+                    match.group(4),
+                    match.group(5),
+                    match.group(6),
                 )
         if (
             from_file0.is_file()
@@ -819,20 +825,25 @@ def from_replace(match):
             or lfrom_file0.is_file()
             or lfrom_file1.is_file()
         ):
-            return b"%s ansible_collections.%s.%s.plugins.module_utils import %s%s" % (
-                match.group(1),
-                bytes(_namespace, "utf-8"),
-                bytes(_collection, "utf-8"),
-                match.group(4),
-                match.group(5),
+            return (
+                b"%s ansible_collections.%s.%s.plugins.module_utils import %s%s%s"
+                % (
+                    match.group(1),
+                    bytes(_namespace, "utf-8"),
+                    bytes(_collection, "utf-8"),
+                    match.group(4),
+                    match.group(5),
+                    match.group(6),
+                )
             )
         else:
-            return b"%s ansible_collections.%s.%s.plugins.module_utils.__init__ import %s%s" % (
+            return b"%s ansible_collections.%s.%s.plugins.module_utils.__init__ import %s%s%s" % (
                 match.group(1),
                 bytes(_namespace, "utf-8"),
                 bytes(_collection, "utf-8"),
                 match.group(4),
                 match.group(5),
+                match.group(6),
             )
     return match.group(0)
 

--- a/tests/unit/test_lsr_role2collection.py
+++ b/tests/unit/test_lsr_role2collection.py
@@ -351,7 +351,7 @@ class LSRRole2Collection(unittest.TestCase):
             "utf-8",
         )
         IMPORT_RE = re.compile(
-            br"(\bimport) (ansible\.module_utils\.)(\S+)(.*)$", flags=re.M
+            br"(\bimport) (ansible\.module_utils\.)(\S+)(\S*)(\s+#.+|.*)$", flags=re.M
         )
         config["namespace"] = namespace
         config["collection"] = collection_name
@@ -398,8 +398,9 @@ class LSRRole2Collection(unittest.TestCase):
                 {0}.{1} import MyError
                 {0}.{1}.{3} import (
                     ArgUtil,
-                    ArgValidator_ListConnections,    ValidationError,
-                )
+                    ArgValidator_ListConnections,
+                    ValidationError,
+                )  # noqa:E501
                 {0}.{1}.{4} import Util
                 {0}.{1} import {5}
                 """
@@ -422,8 +423,9 @@ class LSRRole2Collection(unittest.TestCase):
                 {0}.{1}.{2}.plugins.module_utils.{3}.__init__ import MyError
                 {0}.{1}.{2}.plugins.module_utils.{3}.{5} import (
                     ArgUtil,
-                    ArgValidator_ListConnections,    ValidationError,
-                )
+                    ArgValidator_ListConnections,
+                    ValidationError,
+                )  # noqa:E501
                 {0}.{1}.{2}.plugins.module_utils.{3}.{6} import Util
                 {0}.{1}.{2}.plugins.module_utils.{3} import {7}
                 """
@@ -440,7 +442,7 @@ class LSRRole2Collection(unittest.TestCase):
             "utf-8",
         )
         FROM_RE = re.compile(
-            br"(\bfrom) (ansible\.module_utils\.?)(\S+)? import (\(*(?:\n|\r\n)?)(.+)$",
+            br"(\bfrom) (ansible\.module_utils\.?)(\S+)? import (\(*(?:\n|\r\n)?)(.+)(\s+#.+|.*)$",
             flags=re.M,
         )
         config["namespace"] = namespace


### PR DESCRIPTION
Import statement with a trailing comment like this
  from ansible.module_utils.network_lsr import MyError  # noqa:E501
has to be converted to
  from ansible_collections.fedora.system_roles.plugins.module_utils.network_lsr.__init__ import MyError  # noqa:E501

While examinig the path in module_utils, the comment had to be ingnored
then put back in the converted line.