### PR TITLE
lsr_role2collection.py - converting the value of roletoinclude

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -432,6 +432,10 @@ class LSRFileTransformer(LSRFileTransformerBase):
         """handle vars of Ansible item, or vars from a vars file"""
         for var in a_item.get("vars", []):
             logging.debug(f"\tvar = {var}")
+            if var == "roletoinclude":
+                lsr_rolename = self.src_owner + "." + self.rolename
+                if a_item["vars"][var] == lsr_rolename:
+                    ru_item["vars"][var] = self.prefix + self.rolename
         return
 
     def meta_cb(self, a_item, ru_item):


### PR DESCRIPTION
Converting
roletoinclude: linux-system-roles.ROLENAME
to
roletoinclude: fedora.system_roles.ROLENAME

It is a hack to support tests/tests_include_vars_from_parent.yml
in certificate, kernel_settings, logging, nbde_client, nbde_server,
storage, and vpn.

A side note: Do we want to add tests_include_vars_from_parent.yml and its helper code to the newer roles, e.g., cockpit? (I don't see vars in firewall.)