### PR TITLE
lsr_role2collection.py - the source role path does not have to end with the role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Each option has corresponding environment variable to set.
   --replace-dot REPLACE_DOT        COLLECTION_REPLACE_DOT
   --subrole-prefix SUBROLE_PREFIX  COLLECTION_SUBROLE_PREFIX
 ```
+The default logging level is ERROR.
+To increase the level to INFO, set `LSR_INFO` to `true`.
+To increase the level to DEBUG, set `LSR_DEBUG` to `true`.
 
 ## Table of original and new locations
 

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -390,6 +390,8 @@ FROM_RE = re.compile(
 
 if os.environ.get("LSR_DEBUG") == "true":
     logging.getLogger().setLevel(logging.DEBUG)
+elif os.environ.get("LSR_INFO") == "true":
+    logging.getLogger().setLevel(logging.INFO)
 else:
     logging.getLogger().setLevel(logging.ERROR)
 
@@ -584,7 +586,7 @@ def copy_tree_with_replace(
                 dest = dest_path / "roles" / role / dirname
             else:
                 dest = dest_path / dirname / role
-            print(f"Copying role {src} to {dest}")
+            logging.info(f"Copying role {src} to {dest}")
             if ignoreme:
                 lsr_copytree(
                     src,
@@ -939,7 +941,7 @@ def role2collection():
     role = args.role
     if not role:
         parser.print_help()
-        print("Message: role is not specified.")
+        logging.error("Message: role is not specified.")
         os._exit(errno.EINVAL)
 
     namespace = args.namespace
@@ -967,13 +969,19 @@ def role2collection():
     module_utils_dir = plugin_dir / "module_utils"
     docs_dir = dest_path / "docs"
 
-    _src_path = args.src_path.resolve()
+    src_path = args.src_path.resolve()
     src_owner = args.src_owner
     if not src_owner:
-        src_owner = os.path.basename(_src_path)
-    src_path = Path(_src_path) / role
-    if not src_path.exists():
-        print(f"Error: {src_path} does not exists.")
+        src_owner = os.path.basename(src_path)
+    _tasks_main = src_path / "tasks/main.yml"
+    if not _tasks_main.exists():
+        src_path = src_path / role
+        _tasks_main = src_path / "tasks/main.yml"
+
+    if not _tasks_main.exists():
+        logging.error(
+            f"Neither {src_path} nor {src_path.parent} is a role top directory."
+        )
         sys.exit(errno.ENOENT)
     _extras = set(os.listdir(src_path)).difference(ALL_DIRS)
     try:
@@ -1090,7 +1098,7 @@ def role2collection():
         src = src_path / filename
         dest = roles_dir / rolename / filename
         # copy
-        print(f"Copying doc {filename} to {dest}")
+        logging.info(f"Copying doc {filename} to {dest}")
         copy2(src, dest, follow_symlinks=False)
         dest = roles_dir / rolename
         file_patterns = ["*.md"]
@@ -1107,7 +1115,7 @@ def role2collection():
     for doc in DOCS:
         src = src_path / doc
         if src.is_dir():
-            print(f"Copying docs {src} to {dest}")
+            logging.info(f"Copying docs {src} to {dest}")
             lsr_copytree(
                 src,
                 dest,
@@ -1149,17 +1157,17 @@ def role2collection():
                 if sr.is_dir():
                     # If src/sr is a directory, copy it to the dest
                     dest = plugin_dir / plugin_name / sr.name
-                    print(f"Copying plugin {sr} to {dest}")
+                    logging.info(f"Copying plugin {sr} to {dest}")
                     lsr_copytree(sr, dest)
                 else:
                     # Otherwise, copy it to the plugins/plugin_name/ROLE
                     dest = plugin_dir / plugin_name / role
                     dest.mkdir(parents=True, exist_ok=True)
-                    print(f"Copying plugin {sr} to {dest}")
+                    logging.info(f"Copying plugin {sr} to {dest}")
                     copy2(sr, dest, follow_symlinks=False)
         else:
             dest = plugin_dir / plugin_name
-            print(f"Copying plugin {src} to {dest}")
+            logging.info(f"Copying plugin {src} to {dest}")
             lsr_copytree(src, dest)
 
     # Update the python codes which import modules in plugins/{modules,modules_dir}.
@@ -1183,7 +1191,7 @@ def role2collection():
                         new_text = pattern.sub(rewrite[-1], new_text)
 
                     if text != new_text:
-                        print("Rewriting imports for {}".format(full_path))
+                        logging.info("Rewriting imports for {}".format(full_path))
                         full_path.write_bytes(new_text)
                         additional_rewrites[:] = []
 
@@ -1247,7 +1255,7 @@ def role2collection():
             # Other extra directories are copied to the collection dir as they are.
             else:
                 dest = dest_path / extra.name
-                print(f"Copying extra {extra} to {dest}")
+                logging.info(f"Copying extra {extra} to {dest}")
                 copytree(extra, dest)
         # Other extra files.
         else:
@@ -1262,7 +1270,7 @@ def role2collection():
                 # If the extra file 'filename' has no extension, it is copied to the collection dir as
                 # 'filename-ROLE'. If the extra file is 'filename.ext', it is copied to 'filename-ROLE.ext'.
                 dest = dest_path / add_rolename(extra.name, role)
-            print(f"Copying extra {extra} to {dest}")
+            logging.info(f"Copying extra {extra} to {dest}")
             copy2(extra, dest, follow_symlinks=False)
 
     dest = dest_path / "playbooks" / role


### PR DESCRIPTION
Instead of checking the existence of the path with the role name, use meta/main.yml.
    
Plus, instead of using print, use the logging module to output the log messages.
And introduced an env var LSR_INFO to output the info level messages.
