### PR TITLE
Support include_vars in the test playbooks

### DIFF
--- a/tests/unit/test_lsr_role2collection.py
+++ b/tests/unit/test_lsr_role2collection.py
@@ -262,11 +262,14 @@ class LSRRole2Collection(unittest.TestCase):
             role_path / "tasks", test_yaml_str, pre_params, ".yml", is_vertical=False
         )
         transformer_args = {
+            "namespace": namespace,
+            "collection": collection_name,
             "prefix": prefixdot,
             "subrole_prefix": "",
             "replace_dot": "_",
             "role_modules": set(),
             "src_owner": "linux-system-roles",
+            "top_dir": dest_path,
         }
         copy_tree_with_replace(
             role_path, coll_path, rolename, MYTUPLE, transformer_args, isrole=True


### PR DESCRIPTION
If a test playbook contains a relative path such as
```
  include_vars: relative_path/to/linux-system-roles.ROLENAME/file_or_dir
```
or
```
  include_vars:
    file|dir: relative_path/to/linux-system-roles.ROLENAME/file_or_dir
```
they need to be converted to the absolute path in the collection
format since the test playbook could be located at any place.
According to the include_vars doc, "If the path is relative and not
inside a role, it will be parsed relative to the playbook." To solve
the issue, the relative path is converted to the absolute path.