### PR TITLE
Changing the default collection name from "system_roles" to "linux_system_roles".

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -952,8 +952,8 @@ def role2collection():
     parser.add_argument(
         "--collection",
         type=str,
-        default=os.environ.get("COLLECTION_NAME", "system_roles"),
-        help="Collection name; default to system_roles",
+        default=os.environ.get("COLLECTION_NAME", "linux_system_roles"),
+        help="Collection name; default to linux_system_roles",
     )
     parser.add_argument(
         "--dest-path",


### PR DESCRIPTION
It is based on the feature requirements:
  https://issues.redhat.com/browse/RHELBU-298.