### PR TITLE
lsr_role2collection: bug fixes found in the packaging

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -339,6 +339,7 @@ TOX = (
     ".travis.yml",
     ".yamllint_defaults.yml",
     ".yamllint.yml",
+    ".yamllint.yaml",
     "ansible_pytest_extra_requirements.txt",
     "custom_requirements.txt",
     "molecule",
@@ -361,6 +362,7 @@ DO_NOT_COPY = (
     "scripts",
     "semaphore",
     "standard-inventory-qcow2",
+    "Vagrantfile",
 )
 
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1097,7 +1097,7 @@ def role2collection():
         TESTS,
         transformer_args,
         isrole=False,
-        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__"],
+        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__", ".git*"],
     )
 
     # remove symlinks in the tests/role.
@@ -1313,7 +1313,12 @@ def role2collection():
                         TESTS,
                         transformer_args,
                         isrole=False,
-                        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__"],
+                        ignoreme=[
+                            "artifacts",
+                            "linux-system-roles.*",
+                            "__pycache__",
+                            ".git*",
+                        ],
                     )
                     # remove symlinks in the tests/role.
                     removeme = ["library", "modules", "module_utils", "roles"]

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -363,6 +363,7 @@ DO_NOT_COPY = (
     "semaphore",
     "standard-inventory-qcow2",
     "Vagrantfile",
+    "README.html",
 )
 
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1344,8 +1344,8 @@ def role2collection():
         # Other extra files.
         else:
             if extra.name.endswith(".yml") and "playbook" in extra.name:
-                # some-playbook.yml is copied to playbooks/role dir.
-                dest = dest_path / "playbooks" / role
+                # some-playbook.yml is copied to docs/role dir.
+                dest = dest_path / "docs" / role
                 dest.mkdir(parents=True, exist_ok=True)
             else:
                 # If the extra file 'filename' has no extension, it is copied to the collection dir as
@@ -1354,7 +1354,7 @@ def role2collection():
             logging.info(f"Copying extra {extra} to {dest}")
             copy2(extra, dest, follow_symlinks=False)
 
-    dest = dest_path / "playbooks" / role
+    dest = dest_path / "docs" / role
     if dest.is_dir():
         lsrxfrm = LSRTransformer(
             dest, transformer_args, False, role, LSRFileTransformer

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1280,15 +1280,10 @@ def role2collection():
 
     # ==============================================================================
 
-    # Before handling extra files, clean up tox/travis files.
-    for tox in TOX:
-        tox_obj = dest_path / tox
-        if tox_obj.is_dir():
-            rmtree(tox_obj)
-        elif tox_obj.exists():
-            tox_obj.unlink()
     # Extra files and directories including the sub-roles
     for extra in extras:
+        if extra.name in TOX:
+            continue
         if extra.name.endswith(".md"):
             # E.g., contributing.md, README-devel.md and README-testing.md
             process_readme(extra.parent, extra.name, role)
@@ -1352,9 +1347,6 @@ def role2collection():
                 # some-playbook.yml is copied to playbooks/role dir.
                 dest = dest_path / "playbooks" / role
                 dest.mkdir(parents=True, exist_ok=True)
-            elif extra.name in TOX:
-                # If the file in the TOX tuple, it is copied to the collection dir as it is.
-                dest = dest_path / extra.name
             else:
                 # If the extra file 'filename' has no extension, it is copied to the collection dir as
                 # 'filename-ROLE'. If the extra file is 'filename.ext', it is copied to 'filename-ROLE.ext'.


### PR DESCRIPTION
- Adding Vagrantfile and .yamllint.yaml to TOX list, which are not copied.
-  Adding .git* to the do-not-copy argument in copying tests dir to
      drop .gitignore and .gitkeep.
- TOX files in each role are to be removed, but there were some
      dead codes not making any effects. Replacing them with the
      correct one.
- Selinux role has selinux-playbook.yml in the top level, which used
      to be copied to playbooks/selinux, while other roles' examples are
      copied to the docs/rolename dir. Adjusting selinux behavior to the
      others.
- Adding README.html to DO_NOT_COPY list not to keep them in the
      collection format.