### PR TITLE
lsr_role2collection: bug fixes found in the packaging

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1132,6 +1132,7 @@ def role2collection():
                 {0}
 
                 {1}
+
                 <!--ts-->
                   * [{2}](roles/{3})
                 <!--te-->
@@ -1151,6 +1152,7 @@ def role2collection():
                             """\
 
                         {2}
+
                         <!--ts-->
                           * {3}
                         <!--te-->
@@ -1158,7 +1160,7 @@ def role2collection():
                         ).format(namespace, collection, comment, role_link)
                     )
                 else:
-                    find = r"({0}\n<!--ts-->\n)(( |\*|\w|\[|\]|\(|\)|\.|/|-|\n|\r)+)".format(
+                    find = r"({0}\n\n<!--ts-->\n)(( |\*|\w|\[|\]|\(|\)|\.|/|-|\n|\r)+)".format(
                         comment
                     )
                     replace = r"\1\2  * {0}\n".format(role_link)

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -364,6 +364,7 @@ DO_NOT_COPY = (
     "standard-inventory-qcow2",
     "Vagrantfile",
     "README.html",
+    "CHANGELOG",
 )
 
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY

--- a/lsr_role2collection/collection_readme.md
+++ b/lsr_role2collection/collection_readme.md
@@ -1,7 +1,10 @@
-﻿# Linux System Roles Ansible Collection
+﻿Linux System Roles Ansible Collection
+=====================================
+
 Linux System Roles is a collection of roles for managing Linux system components.
 
 ## Currently supported distributions
+
 * Fedora
 * Red Hat Enterprise Linux (RHEL 6+)
 * RHEL 6+ derivatives such as CentOS 6+
@@ -14,9 +17,11 @@ The following dependency is required for the Ansible Controller:
 * jmespath
 
 ## Installation
+
 There are currently two ways to use the Linux System Roles Collection in your setup.
 
 ### Installation from Ansible Galaxy
+
 You can install the collection from Ansible Galaxy by running:
 ```
 ansible-galaxy collection install fedora.linux_system_roles
@@ -34,6 +39,7 @@ dnf install linux-system-roles
 ```
 
 ## Documentation
+
 A list of all roles and their documentation can be found at https://linux-system-roles.github.io/ as well as in the Supported Roles section.
 
 Once Linux System Roles Collection is installed, the individual role documentation is found at:
@@ -44,7 +50,9 @@ Once Linux System Roles Collection is installed, the individual role documentati
 ## Support
 
 ### Supported Ansible Versions
+
 The supported Ansible versions are aligned with currently maintained Ansible versions that support Collections (Ansible 2.9 and later). You can find the list of maintained Ansible versions [here](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#release-status).
 
 ### Modules and Plugins
+
 The modules and other plugins in this collection are private, used only internally to the collection, unless otherwise noted.


### PR DESCRIPTION
- Markdown sometimes requires a blank line next to heading.
      On some system, '# Heading' is not handled correctly.
      Using '=====', instead.
- Ssd role has CHANGELOG at the top level. Adding it to DO_NOT_COPY.