### PR TITLE
Replacing "a collection of roles" with "a set of roles" in lsr_role2collection/collection_readme.md

### DIFF
--- a/lsr_role2collection/collection_readme.md
+++ b/lsr_role2collection/collection_readme.md
@@ -1,7 +1,7 @@
 ﻿Linux System Roles Ansible Collection
 =====================================
 
-Linux System Roles is a collection of roles for managing Linux system components.
+Linux System Roles is a set of roles for managing Linux system components.
 
 ## Currently supported distributions
 


### PR DESCRIPTION
Per discussion in the meeting, we'd better avoid using the word `collection` to reduce the confusion with `ansible collections`.