### PR TITLE
Commenting out empty dependencies in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ license:
     - MIT
     - BSD-3-Clause
 
-dependencies:
+# dependencies: []
 
 tags:
   - "system"


### PR DESCRIPTION
It is for fixing this failure in the packaging.
```
Traceback (most recent call last):
  File "/usr/lib/rpm/ansible-generator", line 46, in <module>
    main()
  File "/usr/lib/rpm/ansible-generator", line 31, in main
    for dep, req in info.get("dependencies", {}).items():
AttributeError: 'NoneType' object has no attribute 'items'
```