### PR TITLE
Fixing the dependencies value type in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ license:
     - MIT
     - BSD-3-Clause
 
-# dependencies: []
+dependencies: {}
 
 tags:
   - "system"


### PR DESCRIPTION
Note:
Collections that this collection requires to be installed for it to be
usable. The key of the dict is the collection label 'namespace.name'.
The value is a version range
L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification).
Multiple version range specifiers can be set and are separated by ','

dependencies: {}