### PR TITLE
Bug fix in lsr_role2collection.py

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -927,7 +927,7 @@ def add_rolename(filename, rolename):
     """
     if filename.find(".", 1) > 0:
         with_rolename = re.sub(
-            r"([\w\d_\.]*)(\.)([\w\d]*)",
+            r"([\w\d_\.]+)(\.)([\w\d]*)",
             r"\1" + "-" + rolename + r"\2" + r"\3",
             filename,
         )


### PR DESCRIPTION
There was a regex bug.
With the bug an extra file, e.g., .sanity-ansible-ignore-2.9.txt,
was renamed to -ROLENAME.sanity-ansible-ignore-2.9-ROLENAME.txt,
which should be .sanity-ansible-ignore-2.9-ROLENAME.txt.