### PR TITLE
Bug 1935451 - Updates for the Automation Hub release

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -365,6 +365,8 @@ DO_NOT_COPY = (
     "Vagrantfile",
     "README.html",
     "CHANGELOG",
+    "contributing.md",
+    ".dev-tools",
 )
 
 ALL_DIRS = ROLE_DIRS + PLUGINS + TESTS + DOCS + DO_NOT_COPY


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1935451#c10
- Needs to remove .dev-tools/ in the collection packaging.
- contributing.md that refers the directory is also removed from the
  collection.