### PR TITLE
md2html.sh - adding an option -l

### DIFF
--- a/md2html.sh
+++ b/md2html.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
 set -euxo pipefail
+convert_link=0
+while getopts "hl" opt; do
+	case "$opt" in
+		h)
+			echo "Usage: $0 [-h] [[-l] md_file0 md_file1 ...]"
+			exit ;;
+		l)
+			convert_link=1
+			shift ;;
+		*)
+			;;
+	esac
+done
 
 for file in "$@"; do
 	pandoc -f markdown_github "${file}" -t asciidoc -o "${file%.md}.tmp.adoc"
+	if [ "$convert_link" -ne 0 ]; then
+		sed -i -e "s/\.md\>/\.html/g" "${file%.md}.tmp.adoc"
+	fi
 	touch -r "${file}" "${file%.md}.tmp.adoc"
 	TZ=UTC asciidoc -o "${file%.md}.html" -a footer-style=none -a toc2 -a source-highlighter=highlight "${file%.md}.tmp.adoc"
 	rm "${file%.md}.tmp.adoc"


### PR DESCRIPTION
Usage: md2html.sh [-h] [[-l] md_file0 md_file1 ...]
If "-l" is set and if an option md file contains a link to
other md file in it, convert the link to html.