### PR TITLE
Adding a missing E503 to lsr_role2collection/.ansible-lint

### DIFF
--- a/lsr_role2collection/.ansible-lint
+++ b/lsr_role2collection/.ansible-lint
@@ -5,3 +5,4 @@ skip_list:
 - '301' # Commands should not change things if nothing needs doing │
 - '305' # Use shell only when shell functionality is required │
 - '403' # Package installs should not use latest
+- '503' # Tasks that run when changed should likely be handlers


### PR DESCRIPTION
galaxy-importer issues an error in importing the collection to Ansible galaxy:
```
  WARNING: roles/ha_cluster/tasks/cluster-start-and-reload.yml:22:
  [E503] Tasks that run when changed should likely be handlers
```
The error should be suppressed.
