### PR TITLE
Adding check_rpmspec_collection.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ linux-system-roles repos.
   * [sync-template.sh](#sync-templatesh)
   * [lsr_role2collection.py](#lsr_role2collectionpy)
   * [release_collection.py](#release_collectionpy)
+  * [check_rpmspec_collection.sh](#check_rpmspec_collectionsh)
 <!--te-->
 
 
@@ -451,7 +452,7 @@ For each repo, checkout the main branch and make sure it is up-to-date:
 LSR_BASE_DIR=~/working-lsr ./local-repo-dev-sync.sh "git checkout main || git checkout master; git pull"
 ```
 
-The arguments will be passed to `eval` to be evaulated in the context of each
+The arguments will be passed to `eval` to be evaluated in the context of each
 repo.  This is useful if you need to just refresh your local copy of the repo,
 or perform a very simple task in each repo.
 
@@ -518,3 +519,12 @@ EOF
 ```
 If your `$USER` is not the same as your github username, use your github
 username instead of `$USER`.
+
+# check_rpmspec_collection.sh
+
+This script is to be executed in the dist-git directory.
+It locally builds rpm packages with various combination of `ansible` and `collection_artifact` options,
+and checks whether the built rpm count is correct or not.
+Then, it verifies that `README.html` files are only in /usr/share/doc/ area.
+
+Usage: ./check_rpmspec_collection.sh [ -h | --help ] | [ fedpkg | rhpkg [ branch_name ] ]

--- a/check_rpmspec_collection.sh
+++ b/check_rpmspec_collection.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo "Description - Verify rpm package count with various combination of ansible and collection_artifact options."
+    echo "            - Check there is no README.html files in /usr/share/andible/collections."
+    echo "Usage: $0 [ -h | --help ] | [ fedpkg | rhpkg [ branch_name ] ]"
+    exit 0
+fi
+
+if [ "$( find . -maxdepth 1 -name '*.spec' | wc -l )" -ne 1 ]; then
+    echo There must exactly 1 spec file in "$( pwd )".
+    exit 1
+fi
+
+set -euo pipefail
+
+pkgcmd=${1:-"fedpkg"}
+branch=${2:-"rawhide"}
+run() {
+    local option=$1
+    local ext=$2
+    local expect=$3
+    rm -rf noarch
+    output=/tmp/$pkgcmd.$ext
+    cmdline="$pkgcmd --release $branch local $option"
+    echo "$cmdline"
+    $cmdline > "$output" 2>&1
+    count=$( find noarch -name "*.rpm" | wc -l )
+    if [ "$count" -eq "$expect" ]; then
+      echo OK - result "$count" is "$expect"
+    else
+      echo FAILED - result "$count" is not "$expect"
+    fi
+
+    filename=$( "$pkgcmd" --release "$branch" verrel )
+    if rpm -qlp noarch/"${filename}"*.rpm | grep -F '.html' | grep collection | grep -v '/usr/share/doc/'; then
+      echo FAILED - '.html' files are in noarch/"${filename}"*.rpm other than doc
+    else
+      echo OK - '.html' files are only in doc in noarch/"${filename}"*.rpm
+    fi
+}
+
+run "--without ansible" "without_ansible" 1
+run "--without ansible --with collection_artifact" "without_ansible-with_collection_artifact" 1
+run "--without ansible --without collection_artifact" "without_ansible-without_collection_artifact" 1
+run "--without collection_artifact" "without_collection_artifact" 1
+run "--with ansbile --without collection_artifact" "with_ansible-without_collection_artifact" 1
+run "" "no_opt" 1
+run "--with ansbile" "with_ansible" 1
+run "--with collection_artifact" "with_collection_artifact" 2
+run "--with ansible --with collection_artifact" "with_ansible-with_collection_artifact" 2


### PR DESCRIPTION
Description
- Verify rpm package count with various combination of ansible and
              collection_artifact options.
- Check there is no README.html files in /usr/share/andible/collections.

Usage: ./check_rpmspec_collection.sh [ -h | --help ] | [ fedpkg | rhpkg [ branch_name ] ]