### PR TITLE
Fixing issue 65

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                        [--src-path SRC_PATH] [--src-owner SRC_OWNER] [--role ROLE]
                        [--new-role NEW_ROLE] [--replace-dot REPLACE_DOT]
                        [--subrole-prefix SUBROLE_PREFIX] [--readme README]
+                       README] [--extra-mapping EXTRA_MAPPING]
 ```
 
 ### optional arguments
@@ -172,6 +173,18 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                      If sub-role name does not start with the specified value, change
                      the name to start with the value; default to an empty string
 --readme README      Path to the readme file used in top README.md
+--extra-mapping EXTRA_MAPPING
+                     This is a comma delimited list of extra mappings to apply when converting the
+                     files - this converts the given name to collection format with the optional given
+                     namespace and collection.
+                     The format is
+                       "src_name:[[dest_namespace.]dest_collection.]dest_name,\
+                        src_name:[[dest_namespace.]dest_collection.]dest_name,...."
+                     The default for `dest_namespace` is the `--namespace` value,
+                     and the default for `dest_collection` is the `--collection` value.
+                     `src_name` is the name of a role, preferably in `namespace.rolename` format.
+                     If just using `rolename` for `src_name`, and `rolename` is used in places
+                     in the README that you do not want to change.
 ```
 
 ### environment variables

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                      and the default for `dest_collection` is the `--collection` value.
                      `src_name` is the name of a role, preferably in `namespace.rolename` format.
                      If just using `rolename` for `src_name`, and `rolename` is used in places
-                     in the README that you do not want to change.
+                     in the README that you do not want to change, you may have to change the
+                     README in another way, not using this script, by using sed with a custom
+                     regexp..
 ```
 
 ### environment variables

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                        [--src-path SRC_PATH] [--src-owner SRC_OWNER] [--role ROLE]
                        [--new-role NEW_ROLE] [--replace-dot REPLACE_DOT]
                        [--subrole-prefix SUBROLE_PREFIX] [--readme README]
-                       README] [--extra-mapping EXTRA_MAPPING]
+                       [--extra-mapping EXTRA_MAPPING]
 ```
 
 ### optional arguments

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ lsr_role2collection.py [-h] [--namespace NAMESPACE] [--collection COLLECTION]
                      If just using `rolename` for `src_name`, and `rolename` is used in places
                      in the README that you do not want to change, you may have to change the
                      README in another way, not using this script, by using sed with a custom
-                     regexp..
+                     regex.
 ```
 
 ### environment variables

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -565,6 +565,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
                 if role[key].count(".") == 1:
                     _src_owner, _rolename_base = role[key].split(".")
                 else:
+                    _src_owner = None
                     _rolename_base = role[key]
                 if role[key] == lsr_rolename or self.comp_rolenames(
                     role[key], self.newrolename
@@ -573,30 +574,47 @@ class LSRFileTransformer(LSRFileTransformerBase):
                     changed = True
                 elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
                     _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
-                    role[key] = "{0}{1}".format(
-                        self.extra_mapping_dest_prefix[_src_role_index]
-                        if self.extra_mapping_dest_prefix[_src_role_index]
-                        else self.prefix,
-                        self.extra_mapping_dest_role[_src_role_index],
-                    )
-                    changed = True
+                    if (
+                        _src_owner is None
+                        or _src_owner
+                        and (
+                            _src_owner == self.extra_mapping_src_owner[_src_role_index]
+                            or _src_owner == self.src_owner
+                        )
+                    ):
+                        role[key] = "{0}{1}".format(
+                            self.extra_mapping_dest_prefix[_src_role_index]
+                            if self.extra_mapping_dest_prefix[_src_role_index]
+                            else self.prefix,
+                            self.extra_mapping_dest_role[_src_role_index],
+                        )
+                        changed = True
             else:
                 if role.count(".") == 1:
                     _src_owner, _rolename_base = role.split(".")
                 else:
+                    _src_owner = None
                     _rolename_base = role
                 if role == lsr_rolename or self.comp_rolenames(role, self.rolename):
                     role = self.prefix + self.newrolename
                     changed = True
                 elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
                     _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
-                    role = "{0}{1}".format(
-                        self.extra_mapping_dest_prefix[_src_role_index]
-                        if self.extra_mapping_dest_prefix[_src_role_index]
-                        else self.prefix,
-                        self.extra_mapping_dest_role[_src_role_index],
-                    )
-                    changed = True
+                    if (
+                        _src_owner is None
+                        or _src_owner
+                        and (
+                            _src_owner == self.extra_mapping_src_owner[_src_role_index]
+                            or _src_owner == self.src_owner
+                        )
+                    ):
+                        role = "{0}{1}".format(
+                            self.extra_mapping_dest_prefix[_src_role_index]
+                            if self.extra_mapping_dest_prefix[_src_role_index]
+                            else self.prefix,
+                            self.extra_mapping_dest_role[_src_role_index],
+                        )
+                        changed = True
             if changed:
                 item[roles_kw][idx] = role
 

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -411,7 +411,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
             lsr_rolename = self.src_owner + "." + self.rolename
         logging.debug(f"\ttask role {rolename}")
         new_name = None
-        if rolename == self.rolename or rolename == lsr_rolename:
+        if rolename == lsr_rolename or self.comp_rolenames(rolename, self.rolename):
             new_name = self.prefix + self.newrolename
         elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
             _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
@@ -422,13 +422,9 @@ class LSRFileTransformer(LSRFileTransformerBase):
             # or current _rolename_base is SRC_ROLE1
             if (
                 not _src_owner
+                or (_src_owner == self.extra_mapping_src_owner[_src_role_index])
                 or (
-                    _src_owner
-                    and _src_owner == self.extra_mapping_src_owner[_src_role_index]
-                )
-                or (
-                    _src_owner
-                    and not self.extra_mapping_src_owner[_src_role_index]
+                    not self.extra_mapping_src_owner[_src_role_index]
                     and _src_owner == self.src_owner
                 )
             ):
@@ -554,10 +550,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
         else:
             core0 = re.sub("[_\\.]", "", name0)
             core1 = re.sub("[_\\.]", "", name1)
-            if core0 == core1:
-                return True
-            else:
-                return False
+            return core0 == core1
 
     def change_roles(self, item, roles_kw):
         """ru_item is an item which may contain a roles or dependencies

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -422,8 +422,15 @@ class LSRFileTransformer(LSRFileTransformerBase):
             # or current _rolename_base is SRC_ROLE1
             if (
                 not _src_owner
-                or not self.extra_mapping_src_owner[_src_role_index]
-                or _src_owner == self.extra_mapping_src_owner[_src_role_index]
+                or (
+                    _src_owner
+                    and _src_owner == self.extra_mapping_src_owner[_src_role_index]
+                )
+                or (
+                    _src_owner
+                    and not self.extra_mapping_src_owner[_src_role_index]
+                    and _src_owner == self.src_owner
+                )
             ):
                 new_name = "{0}{1}".format(
                     self.extra_mapping_dest_prefix[_src_role_index]

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -130,6 +130,7 @@ class LSRFileTransformerBase(object):
         self.prefix = args["prefix"]
         self.subrole_prefix = args["subrole_prefix"]
         self.replace_dot = args["replace_dot"]
+        self.rolename_regex = "[{0}\\.]".format(self.replace_dot)
         self.role_modules = args["role_modules"]
         self.src_owner = args["src_owner"]
         self.top_dir = args["top_dir"]
@@ -548,8 +549,9 @@ class LSRFileTransformer(LSRFileTransformerBase):
         if name0 == name1:
             return True
         else:
-            core0 = re.sub("[_\\.]", "", name0)
-            core1 = re.sub("[_\\.]", "", name1)
+            # self.rolename_regex is default to "[_\\.]".
+            core0 = re.sub(self.rolename_regex, "", name0)
+            core1 = re.sub(self.rolename_regex, "", name1)
             return core0 == core1
 
     def change_roles(self, item, roles_kw):

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -130,7 +130,7 @@ class LSRFileTransformerBase(object):
         self.prefix = args["prefix"]
         self.subrole_prefix = args["subrole_prefix"]
         self.replace_dot = args["replace_dot"]
-        self.rolename_regex = "[{0}\\.]".format(self.replace_dot)
+        self.rolename_regex = "[{0}.]".format(self.replace_dot)
         self.role_modules = args["role_modules"]
         self.src_owner = args["src_owner"]
         self.top_dir = args["top_dir"]
@@ -436,7 +436,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
                     self.extra_mapping_dest_role[_src_role_index],
                 )
         elif rolename.startswith("{{ role_path }}"):
-            match = re.match(r"{{ role_path }}/roles/([\w\d\.]+)", rolename)
+            match = re.match(r"{{ role_path }}/roles/([\w\d.]+)", rolename)
             if match.group(1).startswith(self.subrole_prefix):
                 new_name = self.prefix + match.group(1).replace(".", self.replace_dot)
             else:
@@ -479,7 +479,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
             To solve it, the relative path is converted to the absolute path.
             """
             _src_owner_match = "/" + self.src_owner + "."
-            _src_owner_pattern = r".*/{0}[.](\w+)/([\w\d\./]+)".format(self.src_owner)
+            _src_owner_pattern = r".*/{0}[.](\w+)/([\w\d./]+)".format(self.src_owner)
             if isinstance(task[module_name], dict):
                 _key = None
                 if (
@@ -549,7 +549,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
         if name0 == name1:
             return True
         else:
-            # self.rolename_regex is default to "[_\\.]".
+            # self.rolename_regex is default to "[_.]".
             core0 = re.sub(self.rolename_regex, "", name0)
             core1 = re.sub(self.rolename_regex, "", name1)
             return core0 == core1

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1341,7 +1341,7 @@ def role2collection():
         dest = roles_dir / new_role
         file_patterns = ["*.md"]
         file_replace(dest, src_owner + "." + role, prefix + new_role, file_patterns)
-        # --extra-mapping SRCROLENAME:DESTROLENAME(or FQDN)
+        # --extra-mapping SRCROLENAME:DESTROLENAME(or FQCN)
         for _emap in extra_mapping:
             _from = "{0}.{1}".format(
                 _emap["src_name"]["src_owner"]

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from shutil import copytree, copy2, copyfile, ignore_patterns, rmtree
 from six import string_types
+from operator import itemgetter
 
 ALL_ROLE_DIRS = [
     "defaults",
@@ -134,6 +135,10 @@ class LSRFileTransformerBase(object):
         self.top_dir = args["top_dir"]
         self.rolename = rolename
         self.newrolename = newrolename
+        self.extra_mapping_src_owner = args["extra_mapping_src_owner"]
+        self.extra_mapping_src_role = args["extra_mapping_src_role"]
+        self.extra_mapping_dest_prefix = args["extra_mapping_dest_prefix"]
+        self.extra_mapping_dest_role = args["extra_mapping_dest_role"]
         buf = open(filepath).read()
         self.ruamel_yaml = YAML(typ="rt")
         match = re.search(LSRFileTransformerBase.HEADER_RE, buf)
@@ -413,10 +418,33 @@ class LSRFileTransformer(LSRFileTransformerBase):
                     break
         if module_name == "include_role" or module_name == "import_role":
             rolename = task[module_name]["name"]
+            if rolename.count(".") == 1:
+                _src_owner, _rolename_base = rolename.split(".")
+            else:
+                _src_owner = None
+                _rolename_base = rolename
             lsr_rolename = self.src_owner + "." + self.rolename
             logging.debug(f"\ttask role {rolename}")
             if rolename == self.rolename or rolename == lsr_rolename:
                 task[module_name]["name"] = self.prefix + self.newrolename
+            elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
+                _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
+                # --extra-mapping "SRC_OWNER0.SRC_ROLE0:DEST_PREFIX[.]DEST_ROLE1,
+                #                  SRC_ROLE1:DEST_PREFIX[.]DEST_ROLE1"
+                # current _rolename_base is SRC_ROLE0 and
+                #   _src_owner is None or _src_owner is SRC_OWNER0
+                # or current _rolename_base is SRC_ROLE1
+                if (
+                    not _src_owner
+                    or not self.extra_mapping_src_owner[_src_role_index]
+                    or _src_owner == self.extra_mapping_src_owner[_src_role_index]
+                ):
+                    task[module_name]["name"] = "{0}{1}".format(
+                        self.extra_mapping_dest_prefix[_src_role_index]
+                        if self.extra_mapping_dest_prefix[_src_role_index]
+                        else self.prefix,
+                        self.extra_mapping_dest_role[_src_role_index],
+                    )
             elif rolename.startswith("{{ role_path }}"):
                 match = re.match(r"{{ role_path }}/roles/([\w\d\.]+)", rolename)
                 if match.group(1).startswith(self.subrole_prefix):
@@ -525,19 +553,50 @@ class LSRFileTransformer(LSRFileTransformerBase):
         lsr_rolename = self.src_owner + "." + self.rolename
         for idx, role in enumerate(item.get(roles_kw, [])):
             changed = False
+            # role could be
+            #   ordereddict([('name', 'linux-system-roles.ROLENAME')])
+            # or
+            #   'linux-system-roles.ROLENAME'
             if isinstance(role, dict):
                 if "name" in role:
                     key = "name"
                 else:
                     key = "role"
+                if role[key].count(".") == 1:
+                    _src_owner, _rolename_base = role[key].split(".")
+                else:
+                    _rolename_base = role[key]
                 if role[key] == lsr_rolename or self.comp_rolenames(
                     role[key], self.newrolename
                 ):
                     role[key] = self.prefix + self.newrolename
                     changed = True
-            elif role == lsr_rolename or self.comp_rolenames(role, self.rolename):
-                role = self.prefix + self.newrolename
-                changed = True
+                elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
+                    _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
+                    role[key] = "{0}{1}".format(
+                        self.extra_mapping_dest_prefix[_src_role_index]
+                        if self.extra_mapping_dest_prefix[_src_role_index]
+                        else self.prefix,
+                        self.extra_mapping_dest_role[_src_role_index],
+                    )
+                    changed = True
+            else:
+                if role.count(".") == 1:
+                    _src_owner, _rolename_base = role.split(".")
+                else:
+                    _rolename_base = role
+                if role == lsr_rolename or self.comp_rolenames(role, self.rolename):
+                    role = self.prefix + self.newrolename
+                    changed = True
+                elif _rolename_base and _rolename_base in self.extra_mapping_src_role:
+                    _src_role_index = self.extra_mapping_src_role.index(_rolename_base)
+                    role = "{0}{1}".format(
+                        self.extra_mapping_dest_prefix[_src_role_index]
+                        if self.extra_mapping_dest_prefix[_src_role_index]
+                        else self.prefix,
+                        self.extra_mapping_dest_role[_src_role_index],
+                    )
+                    changed = True
             if changed:
                 item[roles_kw][idx] = role
 
@@ -1025,6 +1084,16 @@ def role2collection():
         default=os.environ.get("COLLECTION_README", None),
         help="Path to the readme file used in top README.md",
     )
+    parser.add_argument(
+        "--extra-mapping",
+        type=str,
+        default=os.environ.get("COLLECTION_EXTRA_MAPPING", ""),
+        help=(
+            "This is a comma delimited list of extra mappings to apply when "
+            "converting the files - this converts the given name to collection "
+            "format with the optional given namespace and collection."
+        ),
+    )
     args, unknown = parser.parse_known_args()
 
     role = args.role
@@ -1045,6 +1114,78 @@ def role2collection():
     replace_dot = args.replace_dot
     subrole_prefix = args.subrole_prefix
     readme_path = args.readme
+
+    # Input: "linux-system-roles.role0:newrole0,\
+    #         linux-system-roles.role1:fedora.linux_system_roles.role1"
+    # Output:
+    # [
+    #   {'src_name': {'src_owner': 'linux-system-roles', 'role': 'sap-base-settings'},
+    #    'dest_name': {'dest_prefix': None, 'role': ['base_settings']}},
+    #   {'src_name': {'src_owner': 'linux-system-roles', 'role': 'timesync'},
+    #    'dest_name': {'dest_prefix': 'fedora.linux_system_roles', 'role': 'timesync'}}
+    # ]
+    # Note: skip if src role is the role to be converted.
+    def parse_extra_mapping(mapping_str, namespace, role):
+        _mapping_list = mapping_str.split(",")
+        _mapping_dict_list = []
+        for _map in _mapping_list:
+            _item = _map.split(":")
+            if len(_item) == 2:
+                _src = _item[0].split(".")
+                if len(_src) == 1 or len(_src) == 2:
+                    _src_name = {}
+                    if len(_src) == 1:
+                        # "rolename"
+                        _src_name["src_owner"] = None
+                        _src_name["role"] = _src[0]
+                    elif len(_src) == 2:
+                        # "linux-system-roles.rolename"
+                        _src_name["src_owner"] = _src[0]
+                        _src_name["role"] = _src[1]
+                    # Note: skip if src role is the role to be converted.
+                    if _src_name["role"] == role:
+                        continue
+                    _dest = _item[1].split(".")
+                    if len(_dest) > 0 and len(_dest) <= 3:
+                        _dest_name = {}
+                        if len(_dest) == 1:
+                            # "rolename"
+                            _dest_name["dest_prefix"] = None
+                            _dest_name["role"] = _dest[0]
+                        elif len(_dest) == 2:
+                            # "collection.rolename"
+                            _dest_name["dest_prefix"] = "{0}.{1}.".format(
+                                namespace, _dest[0]
+                            )
+                            _dest_name["role"] = _dest[1]
+                        elif len(_dest) == 3:
+                            # "namespace.collection.rolename"
+                            _dest_name["dest_prefix"] = "{0}.{1}.".format(
+                                _dest[0], _dest[1]
+                            )
+                            _dest_name["role"] = _dest[2]
+
+                        _mapping_dict = {}
+                        _mapping_dict["src_name"] = _src_name
+                        _mapping_dict["dest_name"] = _dest_name
+                        _mapping_dict_list.append(_mapping_dict)
+        return _mapping_dict_list
+
+    extra_mapping = parse_extra_mapping(args.extra_mapping, namespace, role)
+    extra_mapping_src_owner = list(
+        map(itemgetter("src_owner"), list(map(itemgetter("src_name"), extra_mapping)))
+    )
+    extra_mapping_src_role = list(
+        map(itemgetter("role"), list(map(itemgetter("src_name"), extra_mapping)))
+    )
+    extra_mapping_dest_prefix = list(
+        map(
+            itemgetter("dest_prefix"), list(map(itemgetter("dest_name"), extra_mapping))
+        )
+    )
+    extra_mapping_dest_role = list(
+        map(itemgetter("role"), list(map(itemgetter("dest_name"), extra_mapping)))
+    )
 
     dest_path = Path.joinpath(
         top_dest_path, "ansible_collections/" + namespace + "/" + collection
@@ -1105,6 +1246,10 @@ def role2collection():
         "role_modules": get_role_modules(src_path),
         "src_owner": src_owner,
         "top_dir": current_dest,
+        "extra_mapping_src_owner": extra_mapping_src_owner,
+        "extra_mapping_src_role": extra_mapping_src_role,
+        "extra_mapping_dest_prefix": extra_mapping_dest_prefix,
+        "extra_mapping_dest_role": extra_mapping_dest_role,
     }
 
     # Role - copy subdirectories, tasks, defaults, vars, etc., in the system role to
@@ -1214,6 +1359,21 @@ def role2collection():
         dest = roles_dir / new_role
         file_patterns = ["*.md"]
         file_replace(dest, src_owner + "." + role, prefix + new_role, file_patterns)
+        # --extra-mapping SRCROLENAME:DESTROLENAME(or FQDN)
+        for _emap in extra_mapping:
+            _from = "{0}.{1}".format(
+                _emap["src_name"]["src_owner"]
+                if _emap["src_name"]["src_owner"]
+                else src_owner,
+                _emap["src_name"]["role"],
+            )
+            _to = "{0}{1}".format(
+                _emap["dest_name"]["dest_prefix"]
+                if _emap["dest_name"]["dest_prefix"]
+                else prefix,
+                _emap["dest_name"]["role"],
+            )
+            file_replace(dest, _from, _to, file_patterns)
         if original:
             file_replace(dest, original, prefix + new_role, file_patterns)
         if filename == "README.md":

--- a/tests/unit/test_lsr_role2collection.py
+++ b/tests/unit/test_lsr_role2collection.py
@@ -25,8 +25,8 @@ namespace = os.environ.get("COLLECTION_NAMESPACE", "fedora")
 collection_name = os.environ.get("COLLECTION_NAME", "system_roles")
 rolename = "systemrole"
 newrolename = "newsystemrole"
-otherroles = ["other0", "other1", "other2", "other3"]
-newotherroles = ["newother0", "newother1", "newother2", "newother3"]
+otherroles = ["other0", "other1", "other2"]
+newotherroles = ["newother0", "newother1", "newother2"]
 prefix = namespace + "." + collection_name
 prefixdot = prefix + "."
 otherprefix = "mynamespace.mycollection"
@@ -453,6 +453,10 @@ class LSRRole2Collection(unittest.TestCase):
             "role_modules": set(),
             "src_owner": "linux-system-roles",
             "top_dir": dest_path,
+            "extra_mapping_src_owner": [],
+            "extra_mapping_src_role": [],
+            "extra_mapping_dest_prefix": [],
+            "extra_mapping_dest_role": [],
         }
         copy_tree_with_replace(
             role_path,
@@ -474,62 +478,54 @@ class LSRRole2Collection(unittest.TestCase):
 
         pre_params = [
             {
-                "key": "roles",
-                "subkey": "-",
-                "value": "linux-system-roles",
-                "delim": ".",
-                "subvalue": otherroles[0],
+                "keyword": "roles",
+                "role_or_task_name": "linux-system-roles." + otherroles[0],
+                "task_subkey": "",
+                "task_value": "",
+                "task_delim": "",
+                "task_subvalue": "",
             },
             {
-                "key": "roles",
-                "subkey": "- name:",
-                "value": "",
-                "delim": "",
-                "subvalue": otherroles[1],
+                "keyword": "tasks",
+                "role_or_task_name": "import_role:",
+                "task_subkey": "name:",
+                "task_value": "linux-system-roles",
+                "task_delim": ".",
+                "task_subvalue": otherroles[1],
             },
             {
-                "key": "import_role",
-                "subkey": "name:",
-                "value": "linux-system-roles",
-                "delim": ".",
-                "subvalue": otherroles[2],
-            },
-            {
-                "key": "include_role",
-                "subkey": "name:",
-                "value": "linux-system-roles",
-                "delim": ".",
-                "subvalue": otherroles[3],
+                "keyword": "tasks",
+                "role_or_task_name": "include_role:",
+                "task_subkey": "name:",
+                "task_value": "linux-system-roles",
+                "task_delim": ".",
+                "task_subvalue": otherroles[2],
             },
         ]
         post_params = [
             {
-                "key": "roles",
-                "subkey": "-",
-                "value": otherprefix,
-                "delim": ".",
-                "subvalue": newotherroles[0],
+                "keyword": "roles",
+                "role_or_task_name": otherprefix + "." + newotherroles[0],
+                "task_subkey": "",
+                "task_value": "",
+                "task_delim": "",
+                "task_subvalue": "",
             },
             {
-                "key": "roles",
-                "subkey": "- name:",
-                "value": prefix,
-                "delim": ".",
-                "subvalue": newotherroles[1],
+                "keyword": "tasks",
+                "role_or_task_name": "import_role:",
+                "task_subkey": "name:",
+                "task_value": otherprefix,
+                "task_delim": ".",
+                "task_subvalue": newotherroles[1],
             },
             {
-                "key": "import_role",
-                "subkey": "name:",
-                "value": otherprefix,
-                "delim": ".",
-                "subvalue": newotherroles[2],
-            },
-            {
-                "key": "include_role",
-                "subkey": "name:",
-                "value": prefix,
-                "delim": ".",
-                "subvalue": newotherroles[3],
+                "keyword": "tasks",
+                "role_or_task_name": "include_role:",
+                "task_subkey": "name:",
+                "task_value": prefix,
+                "task_delim": ".",
+                "task_subvalue": newotherroles[2],
             },
         ]
         MYTUPLE = ("tasks",)
@@ -552,7 +548,6 @@ class LSRRole2Collection(unittest.TestCase):
             "top_dir": dest_path,
             "extra_mapping_src_owner": [
                 "linux-system-roles",
-                None,
                 "linux-system-roles",
                 None,
             ],
@@ -560,18 +555,22 @@ class LSRRole2Collection(unittest.TestCase):
                 otherroles[0],
                 otherroles[1],
                 otherroles[2],
-                otherroles[3],
             ],
-            "extra_mapping_dest_prefix": [otherprefixdot, None, otherprefixdot, None],
+            "extra_mapping_dest_prefix": [otherprefixdot, otherprefixdot, None],
             "extra_mapping_dest_role": [
                 newotherroles[0],
                 newotherroles[1],
                 newotherroles[2],
-                newotherroles[3],
             ],
         }
         copy_tree_with_replace(
-            role_path, coll_path, rolename, MYTUPLE, transformer_args, isrole=True
+            role_path,
+            coll_path,
+            rolename,
+            rolename,
+            MYTUPLE,
+            transformer_args,
+            isrole=True,
         )
         test_path = coll_path / "roles" / rolename / "tasks"
         print(coll_path)


### PR DESCRIPTION
Fixing [lsr_role2collection.py does not convert the legacy role path if the role is not the one to be converted. ](https://github.com/linux-system-roles/auto-maintenance/issues/65)

lsr_role2collection.py - introducing --extra-roles EXTRA_ROLES
    
    The option takes comma separated extra roles to convert to collection.
    This pr fixes the extra roles belonging to the same namespace.collection
    as the role to be converted.
    
    Example:
    python  lsr_role2collection.py --role sap-hana-preconfigure \
      --extra-roles "sap-base-settings,sap-preconfigure"

lsr_role2collection.py - introducing --extra-mapping EXTRA_MAPPING
    
    Comma separated extra mapping - PRE:POST - to replace in the documentation
    
    The option takes comma separated extra string mapping (format PRE:POST)
    applied to the documentations. This option could be useful when a
    role is referred and the role does not belong to the same collection
    as the role to be converted.
    
    Example:
    This command line replaces "linux-system-roles.timesync" with
    "fedora.linux_system_roles.timesync" in the collection converted
    documentation.
    python lsr_role2collection.py --role sap-hana-preconfigure \
      --extra-roles "sap-base-settings,sap-preconfigure" \
      --namespace sap --collection rhel \
      --extra-mapping "linux-system-roles.timesync:fedora.linux_system_roles.timesync"

With these fixes, by running the above example command line, these roles in README.md
```
- 'linux-system-roles.timesync'
- 'linux-system-roles.sap-base-settings' (for RHEL 7.x until RHEL 7.5)
- 'linux-system-roles.sap-preconfigure' (for RHEL 7.6 and later and RHEL 8.x)
        - { role: linux-system-roles.sap-base-settings }
        - { role: linux-system-roles.sap-hana-preconfigure }
```
are converted to
```
- 'fedora.linux_system_roles.timesync'
- 'sap.rhel.sap-base-settings' (for RHEL 7.x until RHEL 7.5)
- 'sap.rhel.sap-preconfigure' (for RHEL 7.6 and later and RHEL 8.x)
          # rhel-system-roles.timesync variables
        - { role: sap.rhel.sap-base-settings }
        - { role: sap.rhel.sap-hana-preconfigure }
```
And these tasks
```
  tasks:
    - name: default run 0
      include_role:
        name: linux-system-roles.sap-preconfigure

    - name: default run 1
      include_role:
        name: linux-system-roles.sap-base-settings

    - name: default run 2
      include_role:
        name: linux-system-roles.sap-hana-preconfigure
```
are converted to
```  tasks:
    - name: default run 0
      include_role:
        name: sap.rhel.sap-preconfigure

    - name: default run 1
      include_role:
        name: sap.rhel.sap-base-settings

    - name: default run 2
      include_role:
        name: sap.rhel.sap-hana-preconfigure
```


