### PR TITLE
lsr_role2collection.py - dropping python-six dependency

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -35,7 +35,6 @@ import textwrap
 from pathlib import Path
 from ruamel.yaml import YAML
 from shutil import copytree, copy2, copyfile, ignore_patterns, rmtree
-from six import string_types
 from operator import itemgetter
 
 ALL_ROLE_DIRS = [
@@ -505,7 +504,7 @@ class LSRFileTransformer(LSRFileTransformerBase):
                         _match.group(2),
                     )
             elif (
-                isinstance(task[module_name], string_types)
+                isinstance(task[module_name], str)
                 and _src_owner_match in task[module_name]
             ):
                 _path = task[module_name]

--- a/lsr_roles2collections.sh
+++ b/lsr_roles2collections.sh
@@ -6,7 +6,7 @@ COLLECTION_SRC_OWNER=${COLLECTION_SRC_OWNER:-"linux-system-roles"}
 COLLECTION_NAMESPACE=${COLLECTION_NAMESPACE:-"fedora"}
 COLLECTION_NAME=${COLLECTION_NAME:-"linux_system_roles"}
 
-ROLES=${ROLES:-"certificate cockpit crypto_policies firewall ha_cluster kdump kernel_settings logging metrics nbde_client nbde_server network postfix selinux sshd storage timesync tlog"}
+ROLES=${ROLES:-"certificate cockpit crypto_policies firewall ha_cluster kdump kernel_settings logging metrics nbde_client nbde_server network postfix selinux sshd storage timesync tlog vpn"}
 CWD=$(pwd)
 
 export COLLECTION_SRC_PATH COLLECTION_DEST_PATH


### PR DESCRIPTION
lsr_role2collection.py - drop python-six dependency
    
Instead of using "six.string_types" to check the task's module name,
use simple "str". If the script is run by python2 and the module name
is not ascii string, we may get unexpected results. But the chance
should be minimum.
