### PR TITLE
pandoc - use gfm instead of markdown

### DIFF
--- a/md2html.sh
+++ b/md2html.sh
@@ -34,7 +34,7 @@ for file in "$@"; do
     --output html "${file}" > "${file%.md}.html"
   # With pandoc, convert to adoc, then to HTML
   elif [ "$md2html_tool" == pandoc ]; then
-    $md2html_tool -f markdown_github "${file}" -t asciidoc -o "${file%.md}.tmp.adoc"
+    $md2html_tool -f gfm "${file}" -t asciidoc -o "${file%.md}.tmp.adoc"
     touch -r "${file}" "${file%.md}.tmp.adoc"
     TZ=UTC asciidoc -o "${file%.md}.html" -a footer-style=none -a toc2 -a source-highlighter=highlight "${file%.md}.tmp.adoc"
     tr -d '\r' < "${file%.md}.html" > "${file%.md}.tmp.adoc"


### PR DESCRIPTION
pandoc should use `gfm` instead of `markdown_github`.  This makes the
internal links in the HTML work when converting the resulting
asciidoc to HTML.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1962976