### PR TITLE
release 1.6.0; add meta/runtime.yml to collection

### DIFF
--- a/collection_release.yml
+++ b/collection_release.yml
@@ -1,7 +1,9 @@
 certificate:
   ref: 1.0.3
+cockpit:
+  ref: 1.0.0
 crypto_policies:
-  ref: 1.0.1
+  ref: 1.1.0
 firewall:
   ref: 0.2.1
 ha_cluster:
@@ -13,7 +15,7 @@ kernel_settings:
 logging:
   ref: 1.3.1
 metrics:
-  ref: 1.2.3
+  ref: 1.2.4
 nbde_client:
   ref: 1.0.4
 nbde_server:
@@ -31,7 +33,7 @@ sshd:
   ref: v0.13.0
   repo: ansible-sshd
 storage:
-  ref: 1.3.1
+  ref: 1.4.0
 timesync:
   ref: 1.5.0
 tlog:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "fedora"
 name: "linux_system_roles"
-version: "1.5.0"
+version: "1.6.0"
 description: "Ansible roles for linux system components management"
 
 authors:

--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.8"


### PR DESCRIPTION
Ansible Galaxy collection import now requires that the collection
has a meta/runtime.yml.  This commit adds support for a default
meta/runtime.yml, and allows the user to override this when using
lsr_role2collection.

Other changes for 1.6.0 release