### PR TITLE
Drop support for Ansible 2.8 by bumping the Ansible version to 2.9

### DIFF
--- a/list-pr-statuses-ghapi.py
+++ b/list-pr-statuses-ghapi.py
@@ -33,7 +33,7 @@ DEFAULT_EXCLUDES = [
     "tuned",
 ]
 
-DEFAULT_ANSIBLES = ["ansible-2.8", "ansible-2.9"]
+DEFAULT_ANSIBLES = ["ansible-2.9"]
 
 DEFAULT_PLATFORMS = [
     "centos-6",
@@ -309,7 +309,7 @@ def main():
             for platform, ansible, env in itertools.product(
                 args.platform, args.ansible, status_env
             )
-            if not (platform.startswith("fedora-") and ansible.endswith("-2.8"))
+            if not (platform.startswith("fedora-") and ansible.endswith("-2.9"))
         ]
     )
 

--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.8"
+requires_ansible: ">=2.9"


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197