### PR TITLE
add bindeps; get rid of requirements.txt

### DIFF
--- a/lsr_role2collection/collection_bindep.txt
+++ b/lsr_role2collection/collection_bindep.txt
@@ -1,0 +1,2 @@
+openssl
+dnf

--- a/lsr_role2collection/collection_requirements.txt
+++ b/lsr_role2collection/collection_requirements.txt
@@ -1,2 +1,0 @@
-jmespath
-netaddr


### PR DESCRIPTION
The vpn role needs bindep `openssl` and `dnf`
We do not require `jmespath` or `netaddr` anymore