### PR TITLE
lsr_role2collection.py - copy each role's README.md and CHANGELOG.md

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1500,6 +1500,18 @@ def role2collection():
     removeme = ["library", "modules", "module_utils", "roles"]
     cleanup_symlinks(dest, new_role, removeme)
 
+    # Copy processed README.md to the docs dir after renaming it to README_ROLENAME.md
+    readme_md = roles_dir / new_role / "README.md"
+    if readme_md.is_file():
+        role_readme_md = docs_dir / "README_{0}.md".format(new_role)
+        copyfile(readme_md, role_readme_md)
+
+    # Copy CHANGELOG.md to the docs dir after renaming it to CHANGELOG_ROLENAME.md
+    changelog_md = src_path / "CHANGELOG.md"
+    if changelog_md.is_file():
+        role_changelog_md = docs_dir / "CHANGELOG_{0}.md".format(new_role)
+        copyfile(changelog_md, role_changelog_md)
+
     # ==============================================================================
 
     # Copy library, module_utils, plugins


### PR DESCRIPTION
Copy each role's `README.md` and `CHANGELOG.md` to the collections doc dir with renamed filename `README_ROLENAME.md` and `CHANGELOG_ROLENAME.md`, respectively.