### PR TITLE
allow lsr_role2collection.py to run on py36

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1504,7 +1504,8 @@ def role2collection():
     readme_md = roles_dir / new_role / "README.md"
     if readme_md.is_file():
         if not docs_dir.is_dir():
-            docs_dir.unlink(missing_ok=True)
+            if docs_dir.exists():
+                docs_dir.unlink()
             docs_dir.mkdir()
         role_readme_md = docs_dir / "README_{0}.md".format(new_role)
         copyfile(readme_md, role_readme_md)
@@ -1513,7 +1514,8 @@ def role2collection():
     changelog_md = src_path / "CHANGELOG.md"
     if changelog_md.is_file():
         if not docs_dir.is_dir():
-            docs_dir.unlink(missing_ok=True)
+            if docs_dir.exists():
+                docs_dir.unlink()
             docs_dir.mkdir()
         role_changelog_md = docs_dir / "CHANGELOG_{0}.md".format(new_role)
         copyfile(changelog_md, role_changelog_md)


### PR DESCRIPTION
The `missing_ok` argument to `Path.unlink` is not available
on python 3.6
