### PR TITLE
add support for creating changelogs for rpm releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,49 +767,6 @@ field if the BZ has been given `Verified:Tested`.
 ITR=9.1.0 ./bz-manage.sh reset_dev_wb
 ```
 
-### get_commit_msg
-Use this to generate a git commit message for a downstream dist-git commit, which
-must be in a specific format.  For example, you have several BZ for ITR 8.7.0 in
-the POST STATUS, and they have been given `release+`, and now you want to make a
-downstream commit, push, and build.
-```
-ITR=8.7.0 STATUS=POST ./bz-manage.sh get_commit_msg
-```
-will output something like this:
-```
-bond: fix typo in supporting the infiniband ports in active-backup mode
-Resolves: rhbz#2064067
-
-pytest failed when running with nm providers in the rhel-8.5 beaker machine
-Resolves: rhbz#2065217
-```
-You must still provide the git commit summary/title, but you can just copy/paste
-this output for the git commit body.
-
-### get_cl
-Use this to generate an RPM spec file Changelog message.  This is similar to
-`get_commit_msg` but it does not require the BZ to have `release+`.  For
-example, you have several BZ for ITR 9.1.0 in the POST STATUS, and you want to
-make an RPM scratch build with a changelog.  You also want to include the cloned
-BZ in the changelog message.
-```
-ITR=9.1.0 STATUS=POST INCLUDE_CLONE=true RPM_CL=true ./bz-manage.sh get_cl
-```
-will output something like this:
-```
-- network - bond: fix typo in supporting the infiniband ports in active-backup mode
-  Resolves: rhbz#2064067 (8.7.0)
-  Resolves: rhbz#2065394 (9.1.0)
-
-- network - pytest failed when running with nm providers in the rhel-8.5 beaker machine
-  Resolves: rhbz#2065217 (8.7.0)
-  Resolves: rhbz#2066911 (9.1.0)
-```
-that you can copy/paste into a spec changelog.  If you do not specify
-`INCLUDE_CLONE=true` then it will output only the BZ for the given ITR.  If you
-do not specify `RPM_CL=true` then the output will be formatted for a git commit
-message rather than for an RPM spec.
-
 ### new
 Create a new system roles BZ.  NOTE: Does not use any environment variables -
 all parameters are passed in on the command line.  All parameters are required.
@@ -846,7 +803,26 @@ e.g.
 ```
 ERROR: bz 2066876 status [POST] does not match clone 2072745 status [ON_QA]
 ```
-The clone check is not perfect, so be sure to check manually. 
+The clone check is not perfect, so be sure to check manually.
+
+### rpm_release
+Use this to generate the following files:
+* cl-md - The new text to add to the CHANGELOG.md
+* cl-spec - The new text to add to the spec %changelog section
+* git-commit-msg - The git commit message
+
+For example - I have several BZ in POST that I am doing a new build for ITR 8.7.0.
+The new version will be 1.20.0.  NOTE that the version in CHANGELOG.md
+is different from the version in the spec file - so you will need to add
+the `-N` for the RELEASE for the spec file version.
+I want to update the CHANGELOG.md, the spec %changelog, and the git commit
+message with the information from all of these BZ, formatted in the correct
+manner for all of these.  You will need to edit all 3 files:
+* Edit CHANGELOG.md and add the contents of cl-md in the right place
+* Edit the spec file to add cl-spec in the right place, and ensure the name
+  and email are correct.
+* Edit the git-commit-msg with the correct git subject line.  You can then
+  use this file with git commit -F
 
 ## Parameters
 

--- a/bz-manage.sh
+++ b/bz-manage.sh
@@ -159,12 +159,12 @@ rpm_release() {
   #   need to edit for name, email
   # - git-commit-msg - in the format required by dist-git
   # - cl-md - the new entry for CHANGELOG.md
+  local version queryurl jq bz summary roles doc_text datesec new_features fixes
   version="$1"; shift
-  local queryurl jq bz summary itr
   queryurl="${BASE_URL}&bug_status=${STATUS}"
   jq='.bugs[] | ((.id|tostring) + "|" + (.whiteboard|gsub("role:"; "")) + "|" + .cf_doc_type + "|" + .summary)'
   datesec=$(date +%s)
-  get_bzs "${queryurl}" "$jq" -r | sort -k 2 -t \| > bzs.raw
+  get_bzs "$queryurl" "$jq" -r | sort -k 2 -t \| > bzs.raw
   cat > "${CL_MD:-cl-md}" <<EOF
 [$version] - $(date -I --date=@"$datesec")
 ----------------------------
@@ -211,9 +211,9 @@ EOF
       { echo ""
         echo "$fix_summary"
         echo "Resolves:rhbz#${bz}"; } >> "${GIT_COMMIT_MSG:-git-commit-msg}"
-      fixes=true
     fi
   done < bzs.raw
+  rm bzs.raw
 }
 
 format_bz_for_md() {

--- a/bz-manage.sh
+++ b/bz-manage.sh
@@ -22,6 +22,7 @@ STATUS=${STATUS:-POST}
 BZ_URL=${URL:-https://bugzilla.redhat.com/buglist.cgi}
 LIMIT=${LIMIT:-100}
 BASE_URL="${BZ_URL}?limit=${LIMIT}&component=${COMPONENT}&${ITR_FIELD}=${ITR}"
+show_url="https://bugzilla.redhat.com/show_bug.cgi?id="
 
 setitmdtm() {
   local field val bzlist baseurl
@@ -65,50 +66,6 @@ reset_dev_wb() {
     set -x
     bugzilla modify --field cf_devel_whiteboard="$newval" "$bz"
     set +x
-  done
-}
-
-# get a list of BZ formatted for dist git BZ checking
-get_commit_msg() {
-  local queryurl jq
-  queryurl="${BASE_URL}&bug_status=${STATUS}&f1=flagtypes.name&o1=substring&v1=release%2B"
-  jq='.bugs[] | ((.id|tostring) + " " + .summary)'
-  get_bzs "${queryurl}" "$jq" -r | while read -r bz summary; do
-    echo "$summary"
-    echo "Resolves: rhbz#$bz"
-    echo ""
-  done
-}
-
-# get a list of BZ formatted for spec changelog or commit msg
-get_cl() {
-  local queryurl jq bz summary clone_bz clone_itr itr sum_prefix bz_prefix
-  queryurl="${BASE_URL}&bug_status=${STATUS}"
-  jq='.bugs[] | ((.id|tostring) + " " + .summary)'
-  get_bzs "${queryurl}" "$jq" -r | while read -r bz summary; do
-    if [ "${INCLUDE_CLONE:-false}" = true ]; then
-      clone_bz=$(get_bz_clone "$bz")
-      clone_itr=$(bugzilla query -b "$clone_bz" --json | jq -r '.bugs[].cf_internal_target_release')
-      clone_itr=" ($clone_itr)"
-      itr=" ($ITR)"
-    else
-      clone_bz=""
-      clone_itr=""
-      itr=""
-    fi
-    if [ "${RPM_CL:-false}" = true ]; then
-      sum_prefix="- "
-      bz_prefix="  "
-    else
-      sum_prefix=""
-      bz_prefix=""
-    fi
-    echo "${sum_prefix}$summary"
-    echo "${bz_prefix}Resolves: rhbz#${bz}${itr}"
-    if [ -n "$clone_itr" ]; then
-      echo "${bz_prefix}Resolves: rhbz#${clone_bz}${clone_itr}"
-    fi
-    echo ""
   done
 }
 
@@ -179,13 +136,193 @@ clone_check() {
   return $rc
 }
 
-case "${1:-}" in
-setitm) setitmdtm itm ;;
-setdtm) setitmdtm dtm ;;
-reset_dev_wb) reset_dev_wb ;;
-get_commit_msg) get_commit_msg ;;
-get_cl) get_cl ;;
-new) shift; new_bz "$@" ;;
-clone_check) clone_check ;;
-*) echo Error - see documentation; exit 1 ;;
-esac
+fmt_summary() {
+  local summary roles
+  summary="$1"
+  roles="$2"
+  if [ -n "$roles" ]; then
+    if [[ "$summary" =~ ^${roles}[\ -]+(.+)$ ]]; then
+      echo "$roles - ${BASH_REMATCH[1]}"
+    else
+      echo "$roles - $summary"
+    fi
+  else
+    echo "$summary"
+  fi
+}
+
+rpm_release() {
+  # look up BZ for given ITR and status (default status is POST)
+  # input is new version - N-V-R format
+  # generate 3 files
+  # - cl-spec - the new %changelog entry for the spec file - user will
+  #   need to edit for name, email
+  # - git-commit-msg - in the format required by dist-git
+  # - cl-md - the new entry for CHANGELOG.md
+  version="$1"; shift
+  local queryurl jq bz summary itr
+  queryurl="${BASE_URL}&bug_status=${STATUS}"
+  jq='.bugs[] | ((.id|tostring) + "|" + (.whiteboard|gsub("role:"; "")) + "|" + .cf_doc_type + "|" + .summary)'
+  datesec=$(date +%s)
+  get_bzs "${queryurl}" "$jq" -r | sort -k 2 -t \| > bzs.raw
+  cat > "${CL_MD:-cl-md}" <<EOF
+[$version] - $(date -I --date=@"$datesec")
+----------------------------
+
+### New Features
+
+EOF
+  echo "* $(LANG=en_US.utf8 date --date=@"$datesec" "+%a %b %d %Y") Your Name <email@redhat.com> - $version" > "${CL_SPEC:-cl-spec}"
+  echo "Package update" > "${GIT_COMMIT_MSG:-git-commit-msg}"
+  new_features=false
+  while IFS=\| read -r bz roles doc_text summary; do
+    fix_summary=$(fmt_summary "$summary" "$roles")
+    if [ "$doc_text" = Enhancement ]; then
+      echo "- [${fix_summary}](${show_url}$bz)" >> "${CL_MD:-cl-md}"
+      echo "- Resolves:rhbz#${bz} : ${fix_summary}" >> "${CL_SPEC:-cl-spec}"
+      { echo ""
+        echo "$fix_summary"
+        echo "Resolves:rhbz#${bz}"; } >> "${GIT_COMMIT_MSG:-git-commit-msg}"
+      new_features=true
+    fi
+  done < bzs.raw
+  if [ "$new_features" = false ]; then
+    echo "- none" >> "${CL_MD:-cl-md}"
+  fi
+  echo "" >> "${CL_MD:-cl-md}"
+  { echo "### Bug Fixes"; echo ""; } >> "${CL_MD:-cl-md}"
+  fixes=false
+  while IFS=\| read -r bz roles doc_text summary; do
+    if [ "$doc_text" = "Bug Fix" ]; then
+      echo "- [${fix_summary}](${show_url}$bz)" >> "${CL_MD:-cl-md}"
+      echo "- Resolves:rhbz#${bz} : ${fix_summary}" >> "${CL_SPEC:-cl-spec}"
+      { echo ""
+        echo "$fix_summary"
+        echo "Resolves:rhbz#${bz}"; } >> "${GIT_COMMIT_MSG:-git-commit-msg}"
+      fixes=true
+    fi
+  done < bzs.raw
+  if [ "$fixes" = false ]; then
+    { echo "- none"; echo ""; } >> "${CL_MD:-cl-md}"
+  fi
+  while IFS=\| read -r bz roles doc_text summary; do
+    if [ "$doc_text" != Enhancement ] && [ "$doc_text" != "Bug Fix" ]; then
+      echo "- Resolves:rhbz#${bz} : ${fix_summary}" >> "${CL_SPEC:-cl-spec}"
+      { echo ""
+        echo "$fix_summary"
+        echo "Resolves:rhbz#${bz}"; } >> "${GIT_COMMIT_MSG:-git-commit-msg}"
+      fixes=true
+    fi
+  done < bzs.raw
+}
+
+format_bz_for_md() {
+  local bz roles doc_text summary nf_file bf_file jq output fix_summary
+  bz="$1"
+  nf_file="$2"
+  bf_file="$3"
+  jq='.bugs[] | ((.whiteboard|gsub("role:"; "")) + "|" + .cf_doc_type + "|" + .summary)'
+  IFS=\| read -r roles doc_text summary <<< "$(bugzilla query -b "$bz" --json | jq -r "$jq")"
+  if [ "${doc_text:-}" = Enhancement ]; then
+    output="$nf_file"
+  elif [ "${doc_text:-}" = "Bug Fix" ]; then
+    output="$bf_file"
+  else
+    echo Skipping "$bz" "${doc_text:-no doc text}" "${summary:-no summary}"
+    return 0
+  fi
+  if [ -n "$roles" ]; then
+    if [[ "$summary" =~ ^${roles}[\ -]+(.+)$ ]]; then
+      fix_summary="$roles - ${BASH_REMATCH[1]}"
+    else
+      fix_summary="$roles - $summary"
+    fi
+  else
+    fix_summary="$summary"
+  fi
+  if [ -f "$output" ]; then
+    if grep -F -q "$fix_summary" "$output" || grep -q "\<${bz}\>" "$output"; then
+      # already in there - skip
+      return 0
+    fi
+  fi
+  echo "- [${fix_summary}](${show_url}$bz)" >> "$output"
+}
+
+make_cl_for_version() {
+  local version datestr cl_file cl_nf_file cl_bf_file
+  version="$1"
+  datestr="$2"
+  cl_file="$3"
+  cl_nf_file="$4"
+  cl_bf_file="$5"
+  if [ ! -f "$cl_nf_file" ] && [ ! -f "$cl_bf_file" ]; then
+    return 0  # no cl for this version
+  fi
+  { echo ""
+    echo ["$version"] - "$datestr"
+    echo ----------------------------
+    echo ""
+    echo "### New Features"
+    echo ""; } >> "$cl_file"
+  if [ -f "$cl_nf_file" ]; then
+    cat "$cl_nf_file" >> "$cl_file"
+  else
+    echo "- none" >> "$cl_file"
+  fi
+  { echo ""
+    echo "### Bug Fixes"
+    echo ""; } >> "$cl_file"
+  if [ -f "$cl_bf_file" ]; then
+    cat "$cl_bf_file" >> "$cl_file"
+  else
+    echo "- none" >> "$cl_file"
+  fi
+  rm -f "$cl_nf_file" "$cl_bf_file"
+}
+
+spec_cl_to_cl_md() {
+  local spec print cur_ver mon day year version datestr cl_file cl_nf_file cl_bf_file
+  spec="$1"
+  print=false
+  version=""
+  cur_ver=""
+  cl_file=".cl.md"
+  cl_nf_file=".cl-nf.md"
+  cl_bf_file=".cl-bf.md"
+  { echo Changelog
+    echo =========; } > "$cl_file"
+  while read -r line ; do
+    if [ "$line" = %changelog ]; then
+      print=true
+      continue
+    fi
+    if [ "$print" = false ]; then
+      continue
+    fi
+    if [[ "$line" =~ ^\*\ +[a-zA-Z]+\ +([a-zA-Z]+)\ +([0-9]+)\ +([0-9]+)\ .*-\ +([0-9]+\.[0-9]+(\.[0-9]+)?)- ]]; then
+      mon="${BASH_REMATCH[1]}"
+      day="${BASH_REMATCH[2]}"
+      year="${BASH_REMATCH[3]}"
+      version="${BASH_REMATCH[4]}"
+      need_new_datestr=false
+      if [ -n "$cur_ver" ] && [ "$version" != "$cur_ver" ]; then
+        make_cl_for_version "$cur_ver" "$datestr" "$cl_file" "$cl_nf_file" "$cl_bf_file"
+        need_new_datestr=true
+      fi
+      if [ -z "${datestr:-}" ] || [ "$need_new_datestr" = true ]; then
+        datestr=$(date --date="$mon $day $year" +%Y-%m-%d)
+      fi
+      cur_ver="$version"
+    elif [[ "$line" =~ bz.?([0-9]{7}) ]]; then
+      while [[ "$line" =~ bz.?([0-9]{7}) ]]; do
+        bz="${BASH_REMATCH[1]}"
+        format_bz_for_md "$bz" "$cl_nf_file" "$cl_bf_file"
+        line="${line/$bz}"
+      done
+    fi
+  done < "$spec"
+  make_cl_for_version "$cur_ver" "$datestr" "$cl_file" "$cl_nf_file" "$cl_bf_file"
+}
+
+"$@"


### PR DESCRIPTION
The function rpm_release will be used to generate the following
files:
* cl-md - the new entry to use for CHANGELOG.md
* cl-spec - the spec file %changelog section update
* git-commit-msg - the git commit message

The initial CHANGELOG.md is generated using spec_cl_to_cl_md.  Then
use rpm_release for subsequent releases.
