### PR TITLE
lsr_role2collection.py --extra-mapping bug fix

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1213,7 +1213,9 @@ def role2collection():
                         _dest_name["role"] = _dest[0]
                     elif len(_dest) == 2:
                         # "collection.rolename" or "namespace.collection"
-                        if _dest[0] == namespace and _dest[1] == collection:
+                        if (
+                            _src[0] == "fedora" and _src[1] == "linux_system_roles"
+                        ) or (_dest[0] == namespace and _dest[1] == collection):
                             _dest_name["dest_coll"] = _item[1]
                         else:
                             _dest_name["dest_prefix"] = "{0}.{1}.".format(


### PR DESCRIPTION
Need an exceptional handling for `fedora.linux_system_roles` mapping.

@spetrosi, this fixed version could be used for your next build with the command line you shared with me. Let me double-check some observations...

The converted collection format contains the following `fedora.linux_system_roles` strings.
```
$ grep -R fedora.linux_system_roles
README.md:ansible-galaxy collection install fedora.linux_system_roles
README.md:After the installation, the roles are available as `fedora.linux_system_roles.<role_name>`.
README.md:/usr/share/ansible/collections/ansible_collections/fedora/linux_system_roles/roles/<role_name>/README.md
.collection/galaxy.yml:  "fedora.linux_system_roles": "*"
docs/CHANGELOG_server.md:- s/System Roles role/fedora.linux_system_roles.role/ to avoid ambiguity (#94)
```
I suppose `README.md` is going to be handled separately. `docs/CHANGELOG_server.md` should be ok; rather it should not be touched. My question is `.collection/galaxy.yml`. Is it a target of conversion? Or it's ok as it is? Or the file should not be there? Thanks.
