### PR TITLE
skip vault-variables.yml - not sure how to configure for vault

### DIFF
--- a/report-modules-plugins.py
+++ b/report-modules-plugins.py
@@ -497,6 +497,9 @@ def os_listdir(from_path):
 def process_yml_file(filepath, ctx):
     ctx.filename = filepath
     ctx.lineno = 0
+    if filepath.endswith("/vault-variables.yml"):
+        logging.debug(f"skipping vault-variables.yml file {filepath}")
+        return
     dl = DataLoader()
     ans_data = dl.load_from_file(filepath)
     if ans_data is None:


### PR DESCRIPTION
Skip parsing the file vault-variables.yml - there won't be any
modules or plugins in this file, or jinja numeric operations -
the file should contain only vault encrypted variables.
