### PR TITLE
ensure pypandoc deps are installed; shellcheck issues; do not add fedora lsr as collection dep

### DIFF
--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -19,40 +19,38 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          set -ex
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt install pandoc
           pip install --upgrade pip
-          pip install --upgrade ansible ansible-galaxy galaxy-importer pypandoc rst2html
+          pip install --upgrade ansible-core galaxy-importer pypandoc rst2html 'zipp>=3.1.0' 'pyyaml<6,>=5.4.1'
           docker --version
-
-      - name: Setup paths
-        id: locations
-        shell: bash
-        run: |
-          echo "dest_path=/var/tmp/collection" >> $GITHUB_OUTPUT
 
       - name: Build and publish the collection
         shell: bash
         run: |
-          set -exu
+          set -euxo pipefail
           # Ensure there is no dest_path before running release_collection.py
-          rm -rf ${{ steps.locations.dest_path }}
-          python ./release_collection.py --debug --dest-path ${{ steps.locations.dest_path }}
+          dest_path=/var/tmp/collection
+          rm -rf "$dest_path"
+          python3 ./release_collection.py --debug --dest-path "$dest_path"
           # We are up to date - exit
           if git diff --quiet; then
-            echo "No roles have new releases - no collection will be published"
+            echo ::info No roles have new releases - no collection will be published
             exit 0
           fi
           # A new collection has been build - find the tarball
-          _tarballs=( $(find ${{ steps.locations.dest_path }} -maxdepth 1 -type f -name '*.tar.gz') )
-          if [[ ${#_tarballs[@]} -ne 1 ]]; then
-            echo "Did not find exactly 1 tarball to publish: ${_tarballs[*]}"
+          _tarballs=( $(find "$dest_path" -maxdepth 1 -type f -name "*.tar.gz") )
+          if [ "${#_tarballs[@]}" -ne 1 ]; then
+            echo ::error "Did not find exactly 1 tarball to publish: ${_tarballs[*]}"
             exit 1
           fi
           # Publish the collection
-          ansible-galaxy collection publish -vv --token ${{ secrets.GALAXY_API_TOKEN }} ${_tarballs[0]}
-          # Push the updated collection_release.yml and galaxy.yml. This step should
+          ansible-galaxy collection publish -vv --token "${{ secrets.GALAXY_API_TOKEN }}" "${_tarballs[0]}"
+          # Push the updated collection files. This step should
           # be last since the previous steps must succeed
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -a -m 'Collection version was updated'
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m "Collection version was updated"
           git push
+          echo ::info Done

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['3.8', '3.9']
+        pyver: ['3.8', '3.9', '3.10']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2

--- a/release_collection.py
+++ b/release_collection.py
@@ -596,6 +596,7 @@ def update_collection(args, galaxy, coll_rel):
             galaxy["name"],
             collection_readme,
         )
+        this_collection = galaxy["namespace"] + "." + galaxy["name"]
         legacy_rqf = "requirements.yml"
         coll_rqf = "collection-requirements.yml"
         for rqf in [legacy_rqf, coll_rqf]:
@@ -618,8 +619,9 @@ def update_collection(args, galaxy, coll_rel):
                     else:
                         coll_name = coll
                         coll_ver = "*"
-                    galaxy_deps = galaxy.setdefault("dependencies", {})
-                    galaxy_deps[coll_name] = coll_ver
+                    if coll_name != this_collection:
+                        galaxy_deps = galaxy.setdefault("dependencies", {})
+                        galaxy_deps[coll_name] = coll_ver
     # Existing changelogs
     orig_cl_file = "lsr_role2collection/COLLECTION_CHANGELOG.md"
     # Collection changelog file path


### PR DESCRIPTION
Use ansible-core instead of ansible - ansible-galaxy is provided by ansible-core
Ensure pypandoc dependencies are installed on ubuntu
Fix some shellcheck issues with shell usage in github action run
Use github action ::info and ::error
Do not add fedora.linux_system_roles as a dependency for itself - this causes a circular
dependency error in galaxy_importer
