### PR TITLE
adding a new role - use ref: null; added ad_integration and podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,15 @@ under the github organization, and the default is the `ROLENAME`, so only use
 this if you need to specify a different name for the role in the collection.
 The `sshd` role currently uses both `org` and `repo`.
 
+To add a new role - add it with a `ref: null` e.g.
+```yaml
+ad_integration:
+  ref: null
+```
+
+Then the next time you run `release_collection.py`, it will know that this is a
+new role and will update the versions accordingly.
+
 Example:
 ```yaml
 certificate:

--- a/collection_release.yml
+++ b/collection_release.yml
@@ -1,3 +1,5 @@
+ad_integration:
+  ref: null
 certificate:
   ref: 1.1.7
 cockpit:
@@ -22,6 +24,8 @@ nbde_server:
   ref: 1.2.0
 network:
   ref: 1.9.1
+podman:
+  ref: null
 postfix:
   ref: 1.3.0
 selinux:


### PR DESCRIPTION
Added ad_integration and podman roles.

When you want to add a new role to the collection, add it in alphabetical order
to collection_release.yml with a `ref: null`.  The next time you use
release_collection.py to build the collection, it will update the ref with the
correct tag.  Also, the changelog will say
```
### New Features
...
- ROLENAME - New Role
...
```
