### PR TITLE
make Markdown the default for CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,9 +511,8 @@ will publish the collection, waiting until it is completed.
 * `--skip-check` - boolean - If set to `true`, check using galaxy-importer is
   skipped. By default, `false`.
 * `--skip-changelog` - boolean - By default, the script will attempt to generate
-  a collection changelog in Rst format from the individual role changelogs, or
-  convert an existing collection changelog from MD to Rst.  Use `--skip-changelog`
-  if you do not want to do any of this.
+  a collection changelog from the individual role changelogs.  Use
+  `--skip-changelog` if you do not want to do this.
 * `--debug` - boolean - By default, the script will only output informational
   messages.  Use `--debug` to see the details.
 * `--rpm` - string - Specifies the rpm file for the input collection. When --rpm
@@ -524,6 +523,9 @@ will publish the collection, waiting until it is completed.
   fails.  No default value.
 * `--extra-mapping` - string - same as the `--extra-mapping` argument to
   lsr_role2collection
+* `--changelog-rst` - boolean - by default, CHANGELOG.rst will not be created -
+  set this to create CHANGELOG.rst from docs/CHANGELOG.md.  You must not use
+  `--skip-changelog` if you want to use `--changelog-rst`.
 
 ## Version
 
@@ -834,21 +836,21 @@ ERROR: bz 2066876 status [POST] does not match clone 2072745 status [ON_QA]
 The clone check is not perfect, so be sure to check manually.
 
 ### rpm_release
-Use `USE_MD=1` to generate the new CHANGELOG text in Markdown.  By default, it
-will use reStructuredText (.rst).
+Use `USE_RST=1` to generate the new CHANGELOG text in rST.  By default, it
+will use Markdown (.md).
 Use this to generate the following files:
-* new-cl.rst or .md - The new text to add to the CHANGELOG.rst or .md
+* new-cl.md or .rst - The new text to add to the CHANGELOG.md or .rst
 * cl-spec - The new text to add to the spec %changelog section
 * git-commit-msg - The git commit message
 
 For example - I have several BZ in POST that I am doing a new build for ITR 8.8.0.
-The new version will be 1.22.0.  NOTE that the version in CHANGELOG.rst
+The new version will be 1.22.0.  NOTE that the version in CHANGELOG.md
 is different from the version in the spec file - so you will need to add
 the `-N` for the RELEASE for the spec file version in cl-spec.
-I want to update the CHANGELOG.rst, the spec %changelog, and the git commit
+I want to update the CHANGELOG.md, the spec %changelog, and the git commit
 message with the information from all of these BZ, formatted in the correct
 manner for all of these.  You will need to edit all 3 files:
-* Edit CHANGELOG.rst and add the contents of new-cl.rst in the right place
+* Edit CHANGELOG.md and add the contents of new-cl.md in the right place
 * Edit the spec file to add cl-spec in the right place, and ensure the name
   and email are correct.
 * Edit the git-commit-msg with the correct git subject line.  You can then
@@ -857,11 +859,11 @@ manner for all of these.  You will need to edit all 3 files:
 Example:
 ```
 ITR=8.8.0 ./bz-manage.sh rpm_release 1.22.0
-# edit CHANGELOG.rst - put the contents of new-cl.rst at the top
+# edit CHANGELOG.md - put the contents of new-cl.md at the top
 # edit the spec file - put the contents of cl-spec at the top
 #   of %changelog - edit the name, email, and add the -N to the version
 # edit git-commit-msg - add a descriptive subject line
-git add CHANGELOG.rst, the spec file, sources, .gitignore ...
+git add CHANGELOG.md, the spec file, sources, .gitignore ...
 git commit -F git-commit-msg
 ```
 

--- a/bz-manage.sh
+++ b/bz-manage.sh
@@ -158,11 +158,11 @@ fmt_summary() {
 # Format a section header like New Features or Bug Fixes for
 # either md or rST
 fmt_section() {
-  if [ -n "${USE_MD:-}" ]; then
-    echo "### $*"
-  else
+  if [ -n "${USE_RST:-}" ]; then
     echo "$@"
     echo "~~~~~~~~~~~~~~"
+  else
+    echo "### $*"
   fi
 }
 
@@ -171,15 +171,15 @@ fmt_bz_for_cl_md_rst() {
   local summary bz
   summary="$1"
   bz="$2"
-  if [ -n "${USE_MD:-}" ]; then
-    echo "- [${summary}](${show_url}$bz)"
-  else
+  if [ -n "${USE_RST:-}" ]; then
     # do some rst fixup
     # convert ` into ``
     # shellcheck disable=SC2001
     # shellcheck disable=SC2016
     summary="$(echo "$summary" | sed 's/\([^`]\)`\([^`]\)/\1``\2/g')"
     echo "- \`${summary} <${show_url}${bz}>\`_"
+  else
+    echo "- [${summary}](${show_url}$bz)"
   fi
 }
 
@@ -191,17 +191,17 @@ rpm_release() {
   #   need to edit for name, email
   # - git-commit-msg - in the format required by dist-git
   # - cl.$suf - the new entry for CHANGELOG - .md or .rst
-  # USE_MD will use .md for suffix and generate markdown - otherwise, .rst and rST
+  # USE_RST will use .rst for suffix and generate rST - otherwise, .md and markdown
   local version queryurl jq bz summary fix_summary roles doc_text datesec new_features fixes suf new_cl
   version="$1"; shift
   queryurl="${BASE_URL}&bug_status=${STATUS}"
   jq='.bugs[] | ((.id|tostring) + "|" + (.whiteboard|gsub("role:"; "")) + "|" + .cf_doc_type + "|" + .summary)'
   datesec=$(date +%s)
   get_bzs "$queryurl" "$jq" -r | sort -k 2 -t \| > bzs.raw
-  if [ -n "${USE_MD:-}" ]; then
-    suf="md"
-  else
+  if [ -n "${USE_RST:-}" ]; then
     suf="rst"
+  else
+    suf="md"
   fi
   new_cl="${NEW_CL:-new-cl.$suf}"
   cat > "$new_cl" <<EOF
@@ -327,10 +327,10 @@ spec_cl_to_cl_md_rst() {
   print=false
   version=""
   cur_ver=""
-  if [ -n "${USE_MD:-}" ]; then
-    suf="md"
-  else
+  if [ -n "${USE_RST:-}" ]; then
     suf="rst"
+  else
+    suf="md"
   fi
   cl_file=".cl.$suf"
   cl_nf_file=".cl-nf.$suf"

--- a/release_collection.py
+++ b/release_collection.py
@@ -678,7 +678,8 @@ def update_collection(args, galaxy, coll_rel):
             if not args.skip_changelog:
                 shutil.copy(orig_cl_file, coll_changelog_path)
                 # Convert CHANGELOG.md to CHANGELOG.rst
-                convert_md2rst(coll_dir)
+                if args.changelog_rst:
+                    convert_md2rst(coll_dir)
             create_collection_extra_files(args, coll_dir, galaxy)
             return
         update_galaxy_version(args, galaxy, versions_updated)
@@ -719,7 +720,8 @@ def update_collection(args, galaxy, coll_rel):
             shutil.copy(orig_cl_file, coll_changelog_path)
 
         # Convert CHANGELOG.md to CHANGELOG.rst
-        convert_md2rst(coll_dir)
+        if args.changelog_rst:
+            convert_md2rst(coll_dir)
     build_collection(args, coll_dir, galaxy)
 
 
@@ -997,6 +999,12 @@ def main():
             "name with collection format with the optional given namespace "
             "and collection as well as the given FQCN with other FQCN."
         ),
+    )
+    parser.add_argument(
+        "--changelog-rst",
+        default=False,
+        action="store_true",
+        help="If true, generate CHANGELOG.rst in collection root directory.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Use Markdown as the default format for CHANGELOG - generate
docs/CHANGELOG.md by default for collections.
