### PR TITLE
Number the roles according to their order in RPM spec

### DIFF
--- a/collection_release.yml
+++ b/collection_release.yml
@@ -1,71 +1,71 @@
-ad_integration:
-  ref: 1.0.0
-  sourcenum: 22
-certificate:
-  ref: 1.1.7
-  sourcenum: 13
-cockpit:
-  ref: 1.4.2
-  sourcenum: 20
-crypto_policies:
-  ref: 1.2.6
-  sourcenum: 14
-firewall:
-  ref: 1.4.1
-  sourcenum: 19
-ha_cluster:
-  ref: 1.8.4
-  sourcenum: 17
+postfix:
+  ref: 1.3.1
+  sourcenum: 1
+selinux:
+  ref: 1.5.0
+  sourcenum: 2
+timesync:
+  ref: 1.7.1
+  sourcenum: 3
 kdump:
   ref: 1.2.5
   sourcenum: 4
+network:
+  ref: 1.11.0
+  sourcenum: 5
+storage:
+  ref: 1.9.4
+  sourcenum: 6
+metrics:
+  ref: 1.8.0
+  sourcenum: 7
+tlog:
+  ref: 1.2.10
+  sourcenum: 8
 kernel_settings:
   ref: 1.1.10
   sourcenum: 9
 logging:
   ref: 1.11.4
   sourcenum: 10
-metrics:
-  ref: 1.8.0
-  sourcenum: 7
-nbde_client:
-  ref: 1.2.8
-  sourcenum: 12
 nbde_server:
   ref: 1.3.0
   sourcenum: 11
-network:
-  ref: 1.11.0
-  sourcenum: 5
-podman:
-  ref: 1.1.0
-  sourcenum: 21
-postfix:
-  ref: 1.3.1
-  sourcenum: 1
-rhc:
-  ref: 1.0.0
-  sourcenum: 23
-selinux:
-  ref: 1.5.0
-  sourcenum: 2
-ssh:
-  ref: 1.1.11
-  sourcenum: 16
+nbde_client:
+  ref: 1.2.8
+  sourcenum: 12
+certificate:
+  ref: 1.1.7
+  sourcenum: 13
+crypto_policies:
+  ref: 1.2.6
+  sourcenum: 14
 sshd:
   org: willshersystems
   ref: v0.18.0
   repo: ansible-sshd
   sourcenum: 15
-storage:
-  ref: 1.9.4
-  sourcenum: 6
-timesync:
-  ref: 1.7.1
-  sourcenum: 3
-tlog:
-  ref: 1.2.10
-  sourcenum: 8
+ssh:
+  ref: 1.1.11
+  sourcenum: 16
+ha_cluster:
+  ref: 1.8.4
+  sourcenum: 17
 vpn:
   ref: 1.5.2
   sourcenum: 18
+firewall:
+  ref: 1.4.1
+  sourcenum: 19
+cockpit:
+  ref: 1.4.2
+  sourcenum: 20
+podman:
+  ref: 1.1.0
+  sourcenum: 21
+ad_integration:
+  ref: 1.0.0
+  sourcenum: 22
+rhc:
+  ref: 1.0.0
+  sourcenum: 23

--- a/collection_release.yml
+++ b/collection_release.yml
@@ -1,48 +1,71 @@
 ad_integration:
   ref: 1.0.0
+  sourcenum: 22
 certificate:
   ref: 1.1.7
+  sourcenum: 13
 cockpit:
   ref: 1.4.2
+  sourcenum: 20
 crypto_policies:
   ref: 1.2.6
+  sourcenum: 14
 firewall:
   ref: 1.4.1
+  sourcenum: 19
 ha_cluster:
   ref: 1.8.4
+  sourcenum: 17
 kdump:
   ref: 1.2.5
+  sourcenum: 4
 kernel_settings:
   ref: 1.1.10
+  sourcenum: 9
 logging:
   ref: 1.11.4
+  sourcenum: 10
 metrics:
   ref: 1.8.0
+  sourcenum: 7
 nbde_client:
   ref: 1.2.8
+  sourcenum: 12
 nbde_server:
   ref: 1.3.0
+  sourcenum: 11
 network:
   ref: 1.11.0
+  sourcenum: 5
 podman:
   ref: 1.1.0
+  sourcenum: 21
 postfix:
   ref: 1.3.1
+  sourcenum: 1
 rhc:
   ref: 1.0.0
+  sourcenum: 23
 selinux:
   ref: 1.5.0
+  sourcenum: 2
 ssh:
   ref: 1.1.11
+  sourcenum: 16
 sshd:
   org: willshersystems
   ref: v0.18.0
   repo: ansible-sshd
+  sourcenum: 15
 storage:
   ref: 1.9.4
+  sourcenum: 6
 timesync:
   ref: 1.7.1
+  sourcenum: 3
 tlog:
   ref: 1.2.10
+  sourcenum: 8
 vpn:
   ref: 1.5.2
+  sourcenum: 18

--- a/release_collection.py
+++ b/release_collection.py
@@ -700,7 +700,7 @@ def update_collection(args, galaxy, coll_rel):
         update_galaxy_version(args, galaxy, versions_updated)
         if not args.no_update:
             with open(args.collection_release_yml.name, "w") as crf:
-                yaml.safe_dump(coll_rel, crf, sort_keys=True)
+                yaml.safe_dump(coll_rel, crf, sort_keys=False)
 
     # If to-be-appended changelogs are found, update COLLECTION_CHANGELOG.md
     # and copy it to the collection docs dir.


### PR DESCRIPTION
Also, sort collection_release.yml according to this number, rather than alphabetically. Having the file sorted by sourcenum makes it easier to add new roles - otherwise it is difficult to figure out what is the last number used.