### PR TITLE
Save the changelog entry for the current version

### DIFF
--- a/release_collection.py
+++ b/release_collection.py
@@ -706,14 +706,16 @@ def update_collection(args, galaxy, coll_rel):
     # and copy it to the collection docs dir.
     if not args.skip_changelog:
         if coll_changelog:
-            this_cl_file = "CURRENT_VER_CHANGELOG.md" if args.save_current_changelog else ""
+            this_cl_file = (
+                "CURRENT_VER_CHANGELOG.md" if args.save_current_changelog else ""
+            )
             clhandle, clname = tempfile.mkstemp(suffix=".cl", prefix="collection")
             with os.fdopen(clhandle, "w") as clf:
                 # Header
                 clf.write("Changelog\n=========\n\n")
                 # New changelogs
                 new_changelog = "[{}] - {}\n---------------------".format(
-                        galaxy["version"], datetime.now().date()
+                    galaxy["version"], datetime.now().date()
                 ) + compact_coll_changelog(coll_changelog)
                 clf.write(new_changelog + "\n")
                 if this_cl_file:
@@ -1027,7 +1029,7 @@ def main():
         "--save-current-changelog",
         default=False,
         action="store_true",
-        help="If true, save the changelog for the current collection version as CURRENT_VER_CHANGELOG.md"
+        help="If true, save the changelog for the current collection version as CURRENT_VER_CHANGELOG.md",
     )
     args = parser.parse_args()
 

--- a/release_collection.py
+++ b/release_collection.py
@@ -706,17 +706,19 @@ def update_collection(args, galaxy, coll_rel):
     # and copy it to the collection docs dir.
     if not args.skip_changelog:
         if coll_changelog:
+            this_cl_file = "CURRENT_VER_CHANGELOG.md" if args.save_current_changelog else ""
             clhandle, clname = tempfile.mkstemp(suffix=".cl", prefix="collection")
             with os.fdopen(clhandle, "w") as clf:
                 # Header
                 clf.write("Changelog\n=========\n\n")
                 # New changelogs
-                clf.write(
-                    "[{}] - {}\n---------------------".format(
+                new_changelog = "[{}] - {}\n---------------------".format(
                         galaxy["version"], datetime.now().date()
-                    )
-                )
-                clf.write(compact_coll_changelog(coll_changelog) + "\n")
+                ) + compact_coll_changelog(coll_changelog)
+                clf.write(new_changelog + "\n")
+                if this_cl_file:
+                    with open(this_cl_file, "w") as tcl:
+                        tcl.write(new_changelog)
                 with open(orig_cl_file, "r") as origclf:
                     _clogs = origclf.read()
                     _clogs = re.sub(
@@ -1020,6 +1022,12 @@ def main():
         default=False,
         action="store_true",
         help="If true, generate CHANGELOG.rst in collection root directory.",
+    )
+    parser.add_argument(
+        "--save-current-changelog",
+        default=False,
+        action="store_true",
+        help="If true, save the changelog for the current collection version as CURRENT_VER_CHANGELOG.md"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
When creating the changelog for the new collection version, the newly prepended changelog entry is saved as CURRENT_VER_CHANGELOG.md in addition to the update of the complete changelog. This is useful when creating a description for a release (because the release description should contain only what's new and not the complete changelog).

Optional, controlled by the `--save-current-changelog` argument.