### PR TITLE
Configure Packit Koji job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,3 +20,7 @@ jobs:
     trigger: release
     dist_git_branches:
       - rawhide
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - rawhide


### PR DESCRIPTION
To build a new RPM after a PR in Pagure is merged.

https://packit.dev/docs/fedora-releases-guide/#koji-build-job

Note: I have not tested this job yet. Let's see...