### PR TITLE
koji and bodhi stuff must be done in dist-git

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,11 +20,3 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-all
-  - job: koji_build
-    trigger: commit
-    dist_git_branches:
-      - fedora-all
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
The koji and bodhi stuff are done in dist-git - see
https://src.fedoraproject.org/rpms/linux-system-roles/blob/rawhide/f/.packit.yaml
