### PR TITLE
update create-release action

### DIFF
--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -88,12 +88,10 @@ jobs:
       - name: Create Release
         id: create_release
         if: ${{ steps.build.outputs.updated == 1 }}
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ steps.build.outputs.tagname }}
-          release_name: Version ${{ steps.build.outputs.tagname }}
-          body_path: ./CURRENT_VER_CHANGELOG.md
-          draft: false
-          prerelease: false
+          tag: ${{ steps.build.outputs.tagname }}
+          name: Version ${{ steps.build.outputs.tagname }}
+          body: ./CURRENT_VER_CHANGELOG.md


### PR DESCRIPTION
The `create-release` action has been deprecated
https://github.com/actions/create-release
the highest rated replacement is
https://github.com/marketplace/actions/create-release
