### PR TITLE
move collection build job one hour later; add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -3,8 +3,8 @@ name: Publish fedora.linux_system_roles collection to Ansible Galaxy
 on:
   workflow_dispatch:
   schedule:
-    # Run daily at 00:37 UTC
-    - cron: '37 0 * * *'
+    # Run daily at 01:37 UTC
+    - cron: '37 1 * * *'
 jobs:
   publish_collection:
     runs-on: ubuntu-latest


### PR DESCRIPTION
packit does maintenence Tuesdays at 0000 UTC, so move the build job
one hour later to give packit plenty of time to recover

Add dependabot checking for github actions in this repo
