### PR TITLE
Add lsr_fingerprint.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ linux-system-roles repos.
   * [bz-manage.sh](#bz-managesh)
   * [check_jenkins.py](#check_jenkinspy)
   * [configure_squid](#configure_squid)
+  * [lsr_fingerprint.py](#lsr_fingerprintpy)
 <!--te-->
 
 
@@ -940,7 +941,7 @@ have failed.  See also `print_task_tests_info`.
 The `configure_squid` directory stores the playbook that you can use to
 configure a Squid caching proxy server for caching RPM packages. The playbook
 copies the `squid.conf` file to the managed node. The `squid.conf` file 
-onfigures Squid to use SSL Bump to cache RPM packages over HTTPS and does some
+configures Squid to use SSL Bump to cache RPM packages over HTTPS and does some
 further configurations required for RPM packages caching. You can compare
 `squid.conf` with `squid.conf.default` to see what `squid.conf` adds.
 
@@ -952,3 +953,16 @@ EL 6 or to /etc/dnf/dnf.conf on EL > 6 and Fedora:
 proxy=http://<squid_server_ip>:3128
 sslverify=False
 ```
+
+# lsr_fingerprint.py
+
+Introduced to modify fingerprint in spec file to be `system_role:$rolename`.
+
+`lsr_fingerprint.py` scans files in the `templates` dir under `./role["lsrrolename"]`,
+if the file contains a string `role["reponame"]:role["rolename"]`,
+replaces it with `system_role:role["lsrrolename"]`. Note: `role` is an entry
+of `roles` that is defined as an array of dictionaries in `lsr_fingerprint.py`.
+
+For example, in metrics, `performancecopilot:ansible-pcp` is replaced with
+`system_role:metrics`; in sshd, `willshersystems:ansible-sshd` is with
+`system_role:sshd`.

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -33,6 +33,7 @@ roles = [
 changedlist = []
 # dirs in the current dir
 dirs = [d for d in listdir(".") if isdir(d)]
+exit_code = 0
 for d in dirs:
     for role in roles:
         if role["lsrrolename"] == d:

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -14,6 +14,7 @@ E.g., in metrics, "performancecopilot:ansible-pcp" is replaced with
 "system_role:metrics" in roles/bpftrace/templates/bpftrace.conf.j2.
 """
 
+import sys
 from os import listdir, walk
 from os.path import join, isfile, isdir
 

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -54,11 +54,19 @@ for d in dirs:
                                     lines = ifp.readlines()
                                 count = 0
                                 newlines = ""
+                                changed = {}
                                 for line in lines:
                                     newline = line.replace(oldpair, newpair)
                                     if newline != line:
+                                        if len(changed) > 0:
+                                            raise Exception(
+                                                "Error: duplicate fingerprint '{0}' found in {1}:{2}".format(
+                                                    line.strip(),
+                                                    tmplpath,
+                                                    count,
+                                                )
+                                            )
                                         changed = {
-                                            "role": role,
                                             "path": tmplpath,
                                             "linenumber": count,
                                             "oldline": line.strip(),
@@ -69,10 +77,10 @@ for d in dirs:
                                     count += 1
                                 with open(tmplpath, "w") as ofp:
                                     ofp.writelines(newlines)
-
-if len(changedlist) > 0:
-    print("Done. Made the following changes:")
-    for changed in changedlist:
-        print("{0}:{1}".format(changed["path"], changed["linenumber"]))
-        print("  old line: {0}".format(changed["oldline"]))
-        print("  new line: {0}".format(changed["newline"]))
+            print(
+                "{0} role done. Made the following changes:".format(role["lsrrolename"])
+            )
+            for changed in changedlist:
+                print("{0}:{1}".format(changed["path"], changed["linenumber"]))
+                print("  old line: {0}".format(changed["oldline"]))
+                print("  new line: {0}".format(changed["newline"]))

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+"""
+Modify fingerprint in spec file to be system_role:$rolename
+
+lsr_fingerprint.py -
+scans files in the templates dir under ./role["lsrrolename"],
+if the file contains a string role["reponame"]:role["rolename"],
+replaces it with system_role:role["lsrrolename"].
+
+E.g., in metrics, "performancecopilot:ansible-pcp" is replaced with
+"system_role:metrics" in roles/bpftrace/templates/bpftrace.conf.j2.
+"""
+
+from os import listdir, walk
+from os.path import join, isfile, isdir
+
+roles = [
+    {
+        "reponame": "willshersystems",
+        "rolename": "ansible-sshd",
+        "lsrrolename": "sshd",
+    },
+    {
+        "reponame": "performancecopilot",
+        "rolename": "ansible-pcp",
+        "lsrrolename": "metrics",
+    },
+]
+
+# dirs in the current dir
+dirs = [d for d in listdir(".") if isdir(d)]
+for d in dirs:
+    for role in roles:
+        if role["lsrrolename"] == d:
+            for root, dirs, files in walk(d):
+                for dir in dirs:
+                    if dir == "templates" or dir == "meta":
+                        dirpath = join(root, dir)
+                        tmpls = [
+                            f for f in listdir(dirpath) if isfile(join(dirpath, f))
+                        ]
+                        for tmpl in tmpls:
+                            tmplpath = join(dirpath, tmpl)
+                            with open(tmplpath) as fp:
+                                lines = fp.read()
+                            newlines = lines.replace(
+                                "{0}:{1}".format(role["reponame"], role["rolename"]),
+                                "system_role:{0}".format(role["lsrrolename"]),
+                            )
+                            if lines != newlines:
+                                with open(tmplpath, "w") as fp:
+                                    fp.write(newlines)

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -35,10 +35,10 @@ dirs = [d for d in listdir(".") if isdir(d)]
 for d in dirs:
     for role in roles:
         if role["lsrrolename"] == d:
-            for root, dirs, files in walk(d):
-                for dir in dirs:
-                    if dir == "templates" or dir == "meta":
-                        dirpath = join(root, dir)
+            for root, subdirs, files in walk(d):
+                for subdir in subdirs:
+                    if subdir == "templates" or subdir == "meta":
+                        dirpath = join(root, subdir)
                         tmpls = [
                             f for f in listdir(dirpath) if isfile(join(dirpath, f))
                         ]

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -86,6 +86,7 @@ for d in dirs:
                 )
                 if changed["duplicate"]:
                     print("  questionable line: {0}".format(changed["oldline"]))
+                    exit_code = 1
                 else:
                     print("  old line: {0}".format(changed["oldline"]))
                     print("  new line: {0}".format(changed["newline"]))

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -52,10 +52,9 @@ for d in dirs:
                             if oldpair in lines:
                                 with open(tmplpath) as ifp:
                                     lines = ifp.readlines()
-                                count = 0
                                 newlines = []
                                 changed = {}
-                                for line in lines:
+                                for lineno, line in enumerate(lines):
                                     newline = line.replace(oldpair, newpair)
                                     if newline != line:
                                         if len(changed) > 0:
@@ -64,14 +63,13 @@ for d in dirs:
                                             dup = False
                                         changed = {
                                             "path": tmplpath,
-                                            "linenumber": count,
+                                            "linenumber": lineno,
                                             "oldline": line.strip(),
                                             "newline": newline.strip(),
                                             "duplicate": dup,
                                         }
                                         changedlist.append(changed)
                                     newlines.append(newline)
-                                    count += 1
                                 with open(tmplpath, "w") as ofp:
                                     ofp.writelines(newlines)
             print(

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -90,3 +90,4 @@ for d in dirs:
                 else:
                     print("  old line: {0}".format(changed["oldline"]))
                     print("  new line: {0}".format(changed["newline"]))
+sys.exit(exit_code)

--- a/lsr_fingerprint.py
+++ b/lsr_fingerprint.py
@@ -49,31 +49,28 @@ for d in dirs:
                             tmplpath = join(dirpath, tmpl)
                             with open(tmplpath) as ifp:
                                 lines = ifp.read()
-                            if lines.find(oldpair):
+                            if oldpair in lines:
                                 with open(tmplpath) as ifp:
                                     lines = ifp.readlines()
                                 count = 0
-                                newlines = ""
+                                newlines = []
                                 changed = {}
                                 for line in lines:
                                     newline = line.replace(oldpair, newpair)
                                     if newline != line:
                                         if len(changed) > 0:
-                                            raise Exception(
-                                                "Error: duplicate fingerprint '{0}' found in {1}:{2}".format(
-                                                    line.strip(),
-                                                    tmplpath,
-                                                    count,
-                                                )
-                                            )
+                                            dup = True
+                                        else:
+                                            dup = False
                                         changed = {
                                             "path": tmplpath,
                                             "linenumber": count,
                                             "oldline": line.strip(),
                                             "newline": newline.strip(),
+                                            "duplicate": dup,
                                         }
                                         changedlist.append(changed)
-                                    newlines = "{0}{1}".format(newlines, newline)
+                                    newlines.append(newline)
                                     count += 1
                                 with open(tmplpath, "w") as ofp:
                                     ofp.writelines(newlines)
@@ -81,6 +78,15 @@ for d in dirs:
                 "{0} role done. Made the following changes:".format(role["lsrrolename"])
             )
             for changed in changedlist:
-                print("{0}:{1}".format(changed["path"], changed["linenumber"]))
-                print("  old line: {0}".format(changed["oldline"]))
-                print("  new line: {0}".format(changed["newline"]))
+                print(
+                    "{0}{1}:{2}".format(
+                        "DUPLICATED - " if changed["duplicate"] else "",
+                        changed["path"],
+                        changed["linenumber"],
+                    )
+                )
+                if changed["duplicate"]:
+                    print("  questionable line: {0}".format(changed["oldline"]))
+                else:
+                    print("  old line: {0}".format(changed["oldline"]))
+                    print("  new line: {0}".format(changed["newline"]))


### PR DESCRIPTION
`lsr_fingerprint` scans files in the `templates` dir under `./role["lsrrolename"]`, if the file contains a string `role["reponame"]:role["rolename"]`, replaces it with `system_role:role["lsrrolename"]`. Note: `role` is an entry of `roles` that is defined as an array of dictionaries in `lsr_fingerprint.py`.

For example, in metrics, `performancecopilot:ansible-pcp` is replaced with `system_role:metrics`; in sshd, `willshersystems:ansible-sshd` is with `system_role:sshd`.