### PR TITLE
Fetch new includes from Fedora distgit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,8 @@ actions:
       - "wget https://src.fedoraproject.org/rpms/linux-system-roles/raw/rawhide/f/linux-system-roles.spec -O linux-system-roles.spec.in"
       - "wget https://src.fedoraproject.org/rpms/linux-system-roles/raw/rawhide/f/extrasources.inc -O extrasources.inc"
       - "wget https://src.fedoraproject.org/rpms/linux-system-roles/raw/rawhide/f/ansible-packaging.inc -O ansible-packaging.inc"
+      - "wget https://src.fedoraproject.org/rpms/linux-system-roles/raw/rawhide/f/vendoring-prep.inc -O vendoring-prep.inc"
+      - "wget https://src.fedoraproject.org/rpms/linux-system-roles/raw/rawhide/f/vendoring-build.inc -O vendoring-build.inc"
       - "./generate_spec_sources.py linux-system-roles.spec.in linux-system-roles.spec"
     changelog-entry: "./generate_rpm_changelog.py"
 jobs:


### PR DESCRIPTION
Before Packit builds the SRPM, it needs to fetch files that are missing from the auto-maintenance repo because they are maintained in Fedora dist-git and not here. This includes the spec file itself and any files that it `%include`s. When new include files (or any other file) are added to dist-git, they need to be added to the Packit configuration as well. Do that for the two newly added include snippets:
`vendoring-prep.inc` and `vendoring-build.inc`.

https://src.fedoraproject.org/rpms/linux-system-roles/pull-request/203 
Fixes #267