### PR TITLE
fix requires_ansible version

### DIFF
--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.11.0"


### PR DESCRIPTION
`2.11.0` is the minimum version supported by ansible-lint/ansible-test
This will not affect using ansible 2.9
