### PR TITLE
ruamel now requires insertion of new key then deletion

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -530,8 +530,9 @@ class LSRFileTransformer(LSRFileTransformerBase):
             logging.debug(f"\ttask role module {role_module_name}")
             # assumes task is an orderreddict
             idx = tuple(task).index(role_module_name)
-            val = task.pop(role_module_name)
+            val = task[role_module_name]
             task.insert(idx, self.prefix + role_module_name, val)
+            del task[role_module_name]
 
     def other_cb(self, item):
         """do something with the other non-task information in an item


### PR DESCRIPTION
The old code would delete the old key using `pop` which would also
retrieve the value of the old key, then insert the new key with the
value at the old index.  This causes ruamel 0.17.23 and later to
crash with an "index out of range" error.  Instead, retrieve the value,
then insert the value with the new key at the old index, then finally
delete the old key.
