### PR TITLE
use markdown parser for role README.md

### DIFF
--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           sudo apt install pandoc
           pip install --upgrade pip
-          pip install --upgrade ansible-core galaxy-importer pypandoc rst2html 'zipp>=3.1.0' 'pyyaml<6,>=5.4.1'
+          pip install --upgrade ansible-core galaxy-importer pypandoc rst2html 'zipp>=3.1.0' 'pyyaml<6,>=5.4.1' markdown
           docker --version
 
       - name: Build and publish the collection


### PR DESCRIPTION
There is a bug in the current implementation.  The latest release
is https://github.com/linux-system-roles/auto-maintenance/commit/c3c7ab34502458e1b1bef9a29b4e1069d95ea27b
as you can see, both storage and rhc had new features, but only the storage
features were added to the changelog.  I tried to figure out how to use
the current code, but I gave up, and instead decided to use
python-markdown as the parser.  This simplified the code a great
deal.  I got rid of the obsoleted code and options.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
