### PR TITLE
fix: gh repo set-default view prints empty string if unset

### DIFF
--- a/manage-role-repos.sh
+++ b/manage-role-repos.sh
@@ -78,7 +78,8 @@ for repo in $repos; do
             echo please use git remote to configure upstream to point to "$LSR_GH_ORG/$repo"
             exit 1
         fi
-        if gh repo set-default xxx/xxx --view 2>&1 | grep -q "no default repository"; then
+        def_repo="$(gh repo set-default xxx/xxx --view 2>&1)"
+        if [ -z "$def_repo" ] || [[ "$def_repo" =~ "no default repository" ]]; then
             gh repo set-default "$LSR_GH_ORG/$repo"
         fi
         # make sure we have a fork of this under our personal space


### PR DESCRIPTION
gh repo set-default --view now prints an empty string if unset,
so check for empty string and the "not set" message.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
