### PR TITLE
support ansible 2.9.10 or later

### DIFF
--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.11.0"
+requires_ansible: ">=2.9.10"


### PR DESCRIPTION
Thanks to @myllynen for figuring how to specify support for
ansible 2.9 or later.

This solves ansible-lint issues such as

```
meta-runtime[unsupported-version] - requires_ansible key must contain a supported version, shown in the list above.
meta-runtime[invalid-version] - requires_ansible key must be a valid version identifier.
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
