### PR TITLE
As part of creating new release, get .README.html from docs branch

### DIFF
--- a/role-make-version-changelog.sh
+++ b/role-make-version-changelog.sh
@@ -306,12 +306,10 @@ You have three options:
             cat "$rel_notes_file" CHANGELOG.md > .tmp-changelog
         fi
         mv .tmp-changelog CHANGELOG.md
-        # Expecting that this script is run from the cloned auto-maintenance repo
-        SCRIPT_DIR="$(dirname -- "$0")"
-        md2html_tool=pandoc sh "$SCRIPT_DIR"/md2html.sh README.md
-        git add CHANGELOG.md README.html
+        git show origin/docs:latest/README.html > .README.html
+        git add CHANGELOG.md .README.html
         { echo "docs(changelog): version $new_tag [citest skip]"; echo "";
-          echo "Update changelog and README.html for version $new_tag"; } > .gitcommitmsg
+          echo "Update changelog and .README.html for version $new_tag"; } > .gitcommitmsg
         git commit -s -F .gitcommitmsg
         rm -f .gitcommitmsg "$rel_notes_file" "$new_features_file" \
             "$bug_fixes_file" "$other_changes_file" "$pr_titles_file" \

--- a/role-make-version-changelog.sh
+++ b/role-make-version-changelog.sh
@@ -306,9 +306,12 @@ You have three options:
             cat "$rel_notes_file" CHANGELOG.md > .tmp-changelog
         fi
         mv .tmp-changelog CHANGELOG.md
-        git add CHANGELOG.md
+        # Expecting that this script is run from the cloned auto-maintenance repo
+        SCRIPT_DIR="$(dirname -- "$0")"
+        md2html_tool=pandoc sh "$SCRIPT_DIR"/md2html.sh README.md
+        git add CHANGELOG.md README.html
         { echo "docs(changelog): version $new_tag [citest skip]"; echo "";
-          echo "Create changelog update and release for version $new_tag"; } > .gitcommitmsg
+          echo "Update changelog and README.html for version $new_tag"; } > .gitcommitmsg
         git commit -s -F .gitcommitmsg
         rm -f .gitcommitmsg "$rel_notes_file" "$new_features_file" \
             "$bug_fixes_file" "$other_changes_file" "$pr_titles_file" \


### PR DESCRIPTION
Keeping .README.html in each role's root dir would help to have a consistent .README.html in RPMs.
Keeping .README.html as a hidden file because it becomes outdated when new changes are made to README.md, and new release hasn't been created yet. The up-to-date README.html is stored in docs branch and is published to GitHub pages of each role as per https://github.com/linux-system-roles/.github/pull/41. 

See RHELPLAN-158622