### PR TITLE
report-modules-plugins add local plugins from tests/library

### DIFF
--- a/report-modules-plugins.py
+++ b/report-modules-plugins.py
@@ -1179,10 +1179,10 @@ class SearchCtx(object):
 def usage():
     return f"""
     You must create an environment (e.g. python venv or VM) which uses
-    ansible 4.x and jinja2.7 e.g.
+    ansible 6.x, and jinja2.7 with python_version <= "3.7", e.g.
       python -mvenv .venv
       . .venv/bin/activate
-      pip install 'ansible==4.*' 'jinja2==2.7.*'
+      pip install 'ansible==6.*' 'jinja2==2.7.*; python_version <= "3.7"'
     Then run this script using that environment.
     Each argument is the name of a directory containing a role, a collection,
     a 'roles' directory containing multiple roles, or an 'ansible_collections'

--- a/report-modules-plugins.py
+++ b/report-modules-plugins.py
@@ -602,6 +602,7 @@ def process_role(role_path, is_real_role, ctx):
             ctx.found_role_name = get_role_name(role_path)
         ctx.enter_role(ctx.found_role_name, role_path)
         ctx.add_local_plugins(role_path, "library")
+        ctx.add_local_plugins(role_path, "tests/library")
         ctx.add_local_plugins(role_path, "filter_plugins")
     # process defaults to get role public api variables
     dirname = "defaults"

--- a/report-modules-plugins.py
+++ b/report-modules-plugins.py
@@ -569,7 +569,7 @@ def process_playbooks_path(playbooks_path, ctx):
         if os.path.isfile(itempath):
             process_ansible_file(itempath, ctx)
     # treat it like a role - look for vars/, tasks/, etc.
-    process_role(playbooks_path, False, ctx)
+    process_role(playbooks_path, True, ctx)
 
 
 def process_role_tests_path(tests_path, ctx):
@@ -602,7 +602,6 @@ def process_role(role_path, is_real_role, ctx):
             ctx.found_role_name = get_role_name(role_path)
         ctx.enter_role(ctx.found_role_name, role_path)
         ctx.add_local_plugins(role_path, "library")
-        ctx.add_local_plugins(role_path, "tests/library")
         ctx.add_local_plugins(role_path, "filter_plugins")
     # process defaults to get role public api variables
     dirname = "defaults"


### PR DESCRIPTION
Specifically, the certificate role stores a module that is used for tests only in tests/library