### PR TITLE
Fix bugs in role-make-version-changelog

### DIFF
--- a/manage-role-repos.sh
+++ b/manage-role-repos.sh
@@ -44,7 +44,7 @@ DEFAULT_EXCLIST=${DEFAULT_EXCLIST:-"test-harness linux-system-roles.github.io sa
                     sap-hana-preconfigure experimental-azure-firstboot sap-preconfigure \
                     auto-maintenance image_builder sap-netweaver-preconfigure ci-testing \
                     meta_test tox-lsr tuned .github lsr-gh-action-py26 \
-                    ee_linux_system_roles ee_linux_automation"}
+                    ee_linux_system_roles ee_linux_automation lsr-woke-action"}
 declare -A EXARRAY
 for repo in $DEFAULT_EXCLIST ${EXCLIST:-}; do
     # EXARRAY is a "set" of excluded repos

--- a/role-make-version-changelog.sh
+++ b/role-make-version-changelog.sh
@@ -160,7 +160,7 @@ else
     fi
 fi
 if [ "$skip" = false ]; then
-    if [ -s "$pr_titles_file" ] && [ "${ALLOW_BAD_PRS}" = false ]; then
+    if [ -s "$pr_titles_file" ] && [ "${ALLOW_BAD_PRS}" = false ] && [ "${count:-0}" != 0 ]; then
         echo ""
         echo Verifying if all PR titles comply with the conventional commits format
         : > $commitlint_errors_file
@@ -306,7 +306,7 @@ You have three options:
             cat "$rel_notes_file" CHANGELOG.md > .tmp-changelog
         fi
         mv .tmp-changelog CHANGELOG.md
-        git show origin/docs:latest/README.html > .README.html
+        gh api /repos/"$owner"/"$repo"/contents/latest/README.html?ref=docs -q .content | base64 --decode > .README.html
         git add CHANGELOG.md .README.html
         { echo "docs(changelog): version $new_tag [citest skip]"; echo "";
           echo "Update changelog and .README.html for version $new_tag"; } > .gitcommitmsg


### PR DESCRIPTION
* Do not verify PR titles with commitlint when there are no PR
* Get docs:latest/README.html using gh api
* In manage-role-repos, ignore lsr-woke-action