### PR TITLE
process action_plugins directory; add --keep option

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -39,6 +39,7 @@ from shutil import copytree, copy2, copyfile, ignore_patterns, rmtree, which
 from operator import itemgetter
 
 ALL_ROLE_DIRS = [
+    "action_plugins",
     "defaults",
     "examples",
     "files",

--- a/release_collection.py
+++ b/release_collection.py
@@ -555,13 +555,14 @@ def update_collection(args, galaxy, coll_rel):
         args.dest_path, "ansible_collections", galaxy["namespace"], galaxy["name"]
     )
     if os.path.isdir(coll_dir):
-        if args.force:
+        if args.keep:
+            pass  # do nothing - keep whatever is there
+        elif args.force:
             shutil.rmtree(coll_dir)
         else:
             raise Exception(
-                "collection dest_path {} already exists - remove or use --force".format(
-                    coll_dir
-                )
+                "collection dest_path {} already exists - remove it, use --force "
+                "to remove, or use --keep".format(coll_dir)
             )
     os.makedirs(coll_dir, exist_ok=True)
     collection_readme = os.path.join("lsr_role2collection", "collection_readme.md")
@@ -844,6 +845,12 @@ def main():
         default=False,
         action="store_true",
         help="Remove collection destination dir and file before creating",
+    )
+    parser.add_argument(
+        "--keep",
+        default=False,
+        action="store_true",
+        help="Keep collection destination dir and file before creating",
     )
     parser.add_argument(
         "--no-auto-version",


### PR DESCRIPTION
Add `action_plugins` to the list of plugin directories to
process

add a `--keep` option for those cases where you need to
prepare	the collection directory ahead of time before
converting the roles

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
