### PR TITLE
ansible-sshd now has a real directory tests/roles/ansible-sshd with role subdir links

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -743,8 +743,8 @@ def cleanup_symlinks(path, role, rmlist):
             if (
                 node.is_dir()
                 and (
-                    r"linux-system-roles." + role == node.name or
-                    (role == "sshd" and node.name == "ansible-sshd")
+                    r"linux-system-roles." + role == node.name
+                    or (role == "sshd" and node.name == "ansible-sshd")
                 )
                 and not any(node.iterdir())
             ):
@@ -1403,7 +1403,13 @@ def role2collection():
         TESTS,
         transformer_args,
         isrole=False,
-        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__", ".git*", "ansible-sshd"],
+        ignoreme=[
+            "artifacts",
+            "linux-system-roles.*",
+            "__pycache__",
+            ".git*",
+            "ansible-sshd",
+        ],
     )
 
     # remove symlinks in the tests/role.

--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -742,7 +742,10 @@ def cleanup_symlinks(path, role, rmlist):
                         node.unlink()
             if (
                 node.is_dir()
-                and r"linux-system-roles." + role == node.name
+                and (
+                    r"linux-system-roles." + role == node.name or
+                    (role == "sshd" and node.name == "ansible-sshd")
+                )
                 and not any(node.iterdir())
             ):
                 node.rmdir()
@@ -1400,7 +1403,7 @@ def role2collection():
         TESTS,
         transformer_args,
         isrole=False,
-        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__", ".git*"],
+        ignoreme=["artifacts", "linux-system-roles.*", "__pycache__", ".git*", "ansible-sshd"],
     )
 
     # remove symlinks in the tests/role.


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
