### PR TITLE
fixes for latest ansible-lint - doc start, ansible 2.13.0

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1021,6 +1021,7 @@ def process_ansible_lint(extra, dest, new_role):
     yml.default_flow_style = False
     yml.preserve_quotes = True
     yml.width = 1024
+    yml.explicit_start = True
 
     with open(extra) as af_src:
         ansible_lint = yml.load(af_src)

--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9.10"
+requires_ansible: ">=2.13.0"

--- a/release_collection.py
+++ b/release_collection.py
@@ -344,7 +344,11 @@ def process_ignore_and_lint_files(args, coll_dir):
                                     ansible_lint[key].append(item)
                                 elif isinstance(ansible_lint[key], dict):
                                     ansible_lint[key][item] = items[item]
-    yaml.safe_dump(ansible_lint, open(os.path.join(coll_dir, ".ansible-lint"), "w"))
+    yaml.safe_dump(
+        ansible_lint,
+        open(os.path.join(coll_dir, ".ansible-lint"), "w"),
+        explicit_start=True,
+    )
 
 
 def role_to_collection(


### PR DESCRIPTION
Ensure .ansible-lint files written by collection conversion/creation
have the `---` doc start.

The meta/runtime.yml needs `requires_ansible: ">=2.13.0"` now.
NOTE that system roles still supports 2.9 and later, but gating
into Ansible repos now requires this.
