### PR TITLE
cast itm and dtm to string when cloning

### DIFF
--- a/jira_playbooks/tasks/clone_and_link_issue.yml
+++ b/jira_playbooks/tasks/clone_and_link_issue.yml
@@ -53,8 +53,8 @@
         qa_ack: "{{ 'QE ack' if clone_issue.meta.fields.customfield_12317366 |
           selectattr('value', 'eq', 'QE ack') | length > 0 else '' }}"
         pool_team: "{{ clone_issue.meta.fields.customfield_12317259.0.value | d('') }}"
-        itm: "{{ clone_issue.meta.fields.customfield_12321040.value | d('') }}"
-        dtm: "{{ clone_issue.meta.fields.customfield_12318141.value | d('') }}"
+        itm: "{{ clone_issue.meta.fields.customfield_12321040.value | d('') | string }}"
+        dtm: "{{ clone_issue.meta.fields.customfield_12318141.value | d('') | string }}"
         itr: "{{ clone_version }}"  # e.g. rhel-X.Y.Z
         version: "{{ clone_version }}"
         status: "{{ clone_issue.meta.fields.status.name }}"


### PR DESCRIPTION
For some reason Ansible casts them to `int`, so convert them back to
string when cloning.
