### PR TITLE
revert min ansible version back to 2.14.0

### DIFF
--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.14.0"


### PR DESCRIPTION
ansible-lint 24.6.0 added a feature which allows you to specify
alternate versions to use instead of the one in meta/runtime.yml by
adding the config option `supported_ansible_also` to .ansible-lint
https://ansible.readthedocs.io/projects/lint/rules/meta-runtime/#configuration

Change this version to 2.14.0.  There will be follow up PRs to add
the option to all role .ansible-lint.

This should allow both ansible-lint and ansible-test to pass.
