### PR TITLE
lsr_role2collection.py: Remove plans directory

### DIFF
--- a/lsr_role2collection.py
+++ b/lsr_role2collection.py
@@ -1359,10 +1359,11 @@ def role2collection():
             extra_script = None
 
     _extras = set(os.listdir(src_path)).difference(ALL_DIRS)
-    try:
-        _extras.remove(".git")
-    except KeyError:
-        pass
+    for dir in (".git", "plans"):
+        try:
+            _extras.remove(dir)
+        except KeyError:
+            pass
     extras = [src_path / e for e in _extras]
 
     global config


### PR DESCRIPTION
The change in https://github.com/linux-system-roles/.github/pull/64 added `plans` directory with test plans to all roles. We do not want this directory to be in converted collections.