### PR TITLE
improvements for role-make-version-changelog.sh

### DIFF
--- a/get-github-stats.sh
+++ b/get-github-stats.sh
@@ -32,7 +32,7 @@ declare -A ISSUES_CREATED_NON_MAINT
 declare -A ISSUES_CLOSED_NON_MAINT
 
 # silence shellcheck about unset vars
-origin_org="${origin_org:?origin_org is unset}"
+upstream_org="${upstream_org:?upstream_org is unset}"
 repo="${repo:?repo is unset}"
 if [ -z "${DATE_RANGE:-}" ]; then
     echo ERROR: Please specify DATE_RANGE like this
@@ -46,7 +46,7 @@ user_is_maintainer() {
     username="$1"
     if [ -z "${USERS[$username]:-}" ]; then
         if gh api --silent \
-          "/repos/$origin_org/$repo/collaborators/$username" 2> /dev/null; then
+          "/repos/$upstream_org/$repo/collaborators/$username" 2> /dev/null; then
             USERS["$username"]=0
         else
             USERS["$username"]=1
@@ -57,14 +57,14 @@ user_is_maintainer() {
 
 # get PRs
 get_prs() {
-    gh pr list -R "$origin_org/$repo" \
+    gh pr list -R "$upstream_org/$repo" \
       -S "created:$DATE_RANGE state:open state:closed" \
       --json number,author,state,title \
       --jq '.[] | "\(.number) \(.author.login) \(.state) \(.title)"'
 }
 
 get_issues() {
-    gh issue list -R "$origin_org/$repo" \
+    gh issue list -R "$upstream_org/$repo" \
       -S "created:$DATE_RANGE state:open state:closed" \
       --json number,author,state \
       --jq '.[] | "\(.number) \(.author.login) \(.state)"'
@@ -122,7 +122,7 @@ if [ -n "${PRS_CSVFILE:-}" ]; then
     fi
     echo "$repo,${PRS_CREATED[$repo]:-0},${PRS_MERGED[$repo]:-0},${PRS_OPEN[$repo]:-0},${PRS_CREATED_NON_MAINT[$repo]:-0},${PRS_MERGED_NON_MAINT[$repo]:-0},${PRS_OPEN_NON_MAINT[$repo]:-0}" >> "$PRS_CSVFILE"
 else
-    echo In the range "$DATE_RANGE" in "$origin_org/$repo":
+    echo In the range "$DATE_RANGE" in "$upstream_org/$repo":
     echo PRs created: "${PRS_CREATED[$repo]:-0}"
     echo PRs merged: "${PRS_MERGED[$repo]:-0}"
     echo PRs open: "${PRS_OPEN[$repo]:-0}"
@@ -136,7 +136,7 @@ if [ -n "${ISSUES_CSVFILE:-}" ]; then
     fi
     echo "$repo,${ISSUES_CREATED[$repo]:-0},${ISSUES_CLOSED[$repo]:-0},${ISSUES_CREATED_NON_MAINT[$repo]:-0},${ISSUES_CLOSED_NON_MAINT[$repo]:-0}" >> "$ISSUES_CSVFILE"
 else
-    echo In the range "$DATE_RANGE" in "$origin_org/$repo":
+    echo In the range "$DATE_RANGE" in "$upstream_org/$repo":
     echo Issues created: "${ISSUES_CREATED[$repo]:-0}"
     echo Issues closed: "${ISSUES_CLOSED[$repo]:-0}"
     echo Issues created by non-maintainers: "${ISSUES_CREATED_NON_MAINT[$repo]:-0}"

--- a/role-manage-dependabot-alerts.sh
+++ b/role-manage-dependabot-alerts.sh
@@ -13,7 +13,7 @@ get_alerts() {
     # shellcheck disable=SC2207
     IFS=$'\n' ALERTS=($(gh api -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "/repos/$origin_org/$repo/dependabot/alerts?state=open&direction=asc" \
+        "/repos/$upstream_org/$repo/dependabot/alerts?state=open&direction=asc" \
         --template \
         '{{tablerow "NUM" "PACKAGE" "FILE" "SUMMARY"}}{{range .}}{{tablerow .number .dependency.package.name .dependency.manifest_path .security_advisory.summary}}{{end}}'))
     unset IFS
@@ -26,7 +26,7 @@ dismiss_alert() {
     comment="$*"
     gh api --method PATCH -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "/repos/$origin_org/$repo/dependabot/alerts/$num" \
+        "/repos/$upstream_org/$repo/dependabot/alerts/$num" \
         -f "state=dismissed" -f "dismissed_reason=$reason" \
         -f "dismissed_comment=$comment"
 }
@@ -77,7 +77,7 @@ EOF
         if [ "$input" = l ]; then
             done=false
         elif [[ "$input" =~ ^v\ ([0-9]+)$ ]]; then
-            xdg-open "https://github.com/$origin_org/$repo/security/dependabot/${BASH_REMATCH[1]}"
+            xdg-open "https://github.com/$upstream_org/$repo/security/dependabot/${BASH_REMATCH[1]}"
             ALERTS=()  # reset for next loop iter
         elif [[ "$input" =~ ^d\ ([0-9]+)\ ([a-z_]+)\ (.+)$ ]]; then
             dismiss_alert "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"


### PR DESCRIPTION
Do not clone repo unless necessary.  This means you can use without
LSR_BASE_DIR.  It will create a tempdir for the cloned repo.

Clean up output a little for readability.

Do not prompt to release role unless AUTOSKIP=false.

Add new feature - AUTOSKIP_PR_TYPES - by default, if the only
changes to the role are `ci` related changes, the script will
skip that role.  If you really want to do a release of a role
which has only `ci` changes, set `AUTOSKIP_PR_TYPES=none`