### PR TITLE
manage_issues.py with ability create multiple issues and epics

### DIFF
--- a/README-manage_issues.md
+++ b/README-manage_issues.md
@@ -4,6 +4,9 @@
 
 Management of Jira issues - create issues, list issues, other issue management
 
+
+## Requirements
+
 Python based
 
 Uses the (https://jira.readthedocs.io/)[python jira] library for the Jira REST
@@ -13,6 +16,25 @@ Uses (https://click.palletsprojects.com/en/8.1.x/)[python click] library for CLI
 option/argument management, instead of the built-in python `argparse` library,
 which allows more complex option/arguments.  This is available in Fedora as the
 `python3-click` package.
+
+### Token
+
+You must have a valid Jira API token.
+
+Log in to your Jira instance.  Go to `Profile -> Personal Access Tokens`.  If
+you do not already have a token that you want to use here, go to `Create token`.
+Copy the token value to `~/.config/jira.yml` which looks like this:
+
+```yaml
+production:
+  token: xxxxTheTokenxxxx
+  url: https://issues.example.com
+current: production
+```
+
+Each item is a context e.g. you can use different contexts for production,
+staging, test, etc. each with a different url and token.  The `current` item is
+the name of the current context you want to use.
 
 ## Commands
 

--- a/README-manage_issues.md
+++ b/README-manage_issues.md
@@ -1,0 +1,163 @@
+# manage_issues.py
+
+## What is it?
+
+Management of Jira issues - create issues, list issues, other issue management
+
+Python based
+
+Uses the (https://jira.readthedocs.io/)[python jira] library for the Jira REST
+API.  This is available in Fedora as the `python3-jira` package.
+
+Uses (https://click.palletsprojects.com/en/8.1.x/)[python click] library for CLI
+option/argument management, instead of the built-in python `argparse` library,
+which allows more complex option/arguments.  This is available in Fedora as the
+`python3-click` package.
+
+## Commands
+
+### create-issue
+
+Create a Jira issue.  There are 3 main ways to create an issue:
+
+* `--github-url` - use the data from a github PR or issue - summary, description, role,
+  status, and doc fields will be set, and the new issue will have a remote link
+  to the github issue
+* `--base-issue` - use the summary, labels, and github remote link from the given issue
+* specify all fields individually
+
+#### project
+
+Required - name of Jira project
+
+#### issue-type
+
+Required if not using `--github-url` - Jira issue type ("Task", "Bug", etc.) - if using `--github-url` then the issue type will be determined by the Conventional Commit
+format of the PR title (e.g. `feat:` is `Story`, `fix:` is `Bug`)
+
+#### version
+
+Fix version e.g. `rhel-9.6`
+
+#### itm
+
+Internal target milestone e.g. `19`
+
+#### dtm
+
+Dev target milestone e.g. `15`
+
+#### dev_ack
+
+Set the Dev ack e.g. `Dev ack`
+
+#### status
+
+"In Progress", "Planning", etc. - if using `--github-url`, then will default to
+"In Progress" for merged PRs, "Planning" otherwise
+
+#### severity
+
+"Critical", "Moderate", etc.
+
+#### summary
+
+The title of the issue - if using `--github-url`, will use the PR/issue title -
+if using `--base-issue`, then you can specify `--summary` with `{issue_summary}`
+in the string e.g. `--summary 'packaging work for {issue_summary}'` - this also
+works when using `--github-url` for subsequent `create-issue`
+
+#### description
+
+The description of the issue - if using `--github-url`, will use the PR/issue
+body - if using `--base-issue`, then you can specify `--description` with
+`{issue_summary}` in the string e.g. `--description 'packaging work for
+{issue_summary}'` - this also works when using `--github-url` for subsequent
+`create-issue`
+
+#### epic-name
+
+This is the name of the epic when creating a `--issue-type Epic` - if using
+`--github-url` or `--base-issue` you can use `{issue_summary}` in the string
+e.g. `--epic-name '[Epic] for {issue_summary}`
+
+
+#### role
+
+One or more role names to associate with the issue.  If more than one, specify
+the argument multiple times on the command line e.g. `--role kdump --role ssh`
+
+#### doc-text-type
+
+Sets the field `Release Note Type` in the issue - see help for option values -
+if using `--github-url` this will be derived like `issue-type`
+
+#### doc-text
+
+The text to use for the `Release Note`.  If using `--github-url`, this will
+use the PR body.
+
+#### docs-impact
+
+`Yes` if this will impact documentation, otherwise `No`
+
+#### story-points
+
+Number of story points to assign to issue
+
+#### sprint
+
+Not supported yet
+
+#### label
+
+One or more labels.  To specify more than one, use `--label foo --label bar`
+
+#### product
+
+product
+
+#### epic-issue-link
+
+One or more other issues to assign to the epic when creating an epic.  This is
+useful if there are already Jira issues created that you want to link into
+the epic `--epic-issue-link PROJECT-123 --epic-issue-link ANOTHER-456`
+
+### Example
+
+Create a product bug/story in the product project from a github PR, an upstream
+tracking task, a downstream packaging task, and an epic to contain them:
+
+```bash
+manage_issues.py create-issue --project PRODPROJ --component my-component \
+    --github-url https://github.com/linux-system-roles/ROLE/pull/999 --version rhel-9.6 --itm 26 --dtm 22 --story-points 5 --status New --severity Low \
+  create-issue --project TEAM --summary 'upstream work for {issue_summary}' \
+    --description 'upstream work for {issue_summary}' --issue-type Task --story-points 1 \
+    --label upstream --status "In Progress" \
+  create-issue --project TEAM --summary 'packaging work for {issue_summary}' \
+    --description 'packaging work for {issue_summary}' --issue-type Task --story-points 1 \
+    --label packaging \
+  create-issue --project TEAM --issue-type Epic --epic-name '[Epic]: {issue_summary}' \
+    --summary '[Epic]: {issue_summary}' \
+    --description 'tracker for all tasks related to {issue_summary}'
+```
+
+There is already a `PRODPROJ` issue, and we just want to create the other tracking
+tasks/epics in our TEAM project, plus add a link to another issue to the epic -
+this assumes `PRODPROJ-999` already has a label like `system_role_ROLENAME`, and
+has a remote link to the github PR/issue:
+
+```bash
+manage_issues.py create-issue --base-issue PRODPROJ-999 --project TEAM \
+    --summary 'upstream work for {issue_summary}' \
+    --description 'upstream work for {issue_summary}' --issue-type Task --story-points 1 \
+    --label upstream --status "In Progress" \
+  create-issue --base-issue PRODPROJ-999 --project TEAM \
+    --summary 'packaging work for {issue_summary}' \
+    --description 'packaging work for {issue_summary}' --issue-type Task --story-points 1 \
+    --label packaging \
+  create-issue  --base-issue PRODPROJ-999 --project TEAM --issue-type Epic \
+    --epic-name '[Epic]: {issue_summary}' --summary '[Epic]: {issue_summary}' \
+    --description 'tracker for all tasks related to {issue_summary}' \
+    --epic-issue-link ANOTHER-555
+```

--- a/README-manage_issues.md
+++ b/README-manage_issues.md
@@ -52,6 +52,10 @@ Create a Jira issue.  There are 3 main ways to create an issue:
 
 Required - name of Jira project
 
+#### component
+
+Value for Jira component field
+
 #### issue-type
 
 Required if not using `--github-url` - Jira issue type ("Task", "Bug", etc.) - if using `--github-url` then the issue type will be determined by the Conventional Commit
@@ -145,7 +149,70 @@ One or more other issues to assign to the epic when creating an epic.  This is
 useful if there are already Jira issues created that you want to link into
 the epic `--epic-issue-link PROJECT-123 --epic-issue-link ANOTHER-456`
 
-### Example
+### dump-issue
+
+Print one or more issues in JSON format.
+
+```bash
+manage_issues.py dump-issues PROJECT-123 PROJECT-456 ....
+```
+
+### rpm-release
+
+Doing an RPM release requires several types of text - spec file `%changelog`, CHANGELOG.md,
+git commit message, and a list of issues.  `rpm-release` will create those for you in
+several files - `cl-spec`, `cl-md`, `git-commit-msg`, and `issue-list`.
+
+```bash
+manage_issues.py --project PROJECT --component my-package --rpm-version 1.90.0-0.1 \
+  --status "In Progress" --version rhel-9.6
+```
+
+#### project
+
+Required - name of Jira project
+
+#### component
+
+Value for Jira component field
+
+#### issue-type
+
+Jira issue type ("Task", "Bug", etc.) - default is `("Bug", "Story")`
+
+#### version
+
+Fix version e.g. `rhel-9.6`
+
+#### status
+
+Issue status - default is `"In Progress"`
+
+#### role
+
+One or more role names to associate with the issue.  If more than one, specify
+the argument multiple times on the command line e.g. `--role kdump --role ssh`
+
+#### label
+
+One or more labels.  To specify more than one, use `--label foo --label bar`
+
+#### fields
+
+One or more fields to return in the search.  The default is `("summary", "labels", "issuetype")`
+The code right now is more or less hard coded to expect and output these fields.
+
+#### jql
+
+A Jira JQL query to use in the search rather than a search string constructed from
+the options above.
+
+#### rpm-version
+
+This is the version number to use for the RPM update e.g. `1.88.9-0.1`.  This will
+be used in `cl-spec`, `cl-md`, and `git-commit-msg`.
+
+## Examples
 
 Create a product bug/story in the product project from a github PR, an upstream
 tracking task, a downstream packaging task, and an epic to contain them:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ linux-system-roles repos.
   * [configure_squid](#configure_squid)
   * [lsr_fingerprint.py](#lsr_fingerprintpy)
   * [get-github-stats.sh](#get-github-statssh)
+  * [manage_issues.py](README-managed_issues.md)
 <!--te-->
 
 

--- a/manage_issues.py
+++ b/manage_issues.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2020, Red Hat, Inc.
+# Copyright: (c) 2024, Red Hat, Inc.
 # SPDX-License-Identifier: MIT
-"""This script is used to manage Bugzilla and Jira issues
+"""This script is used to manage Jira issues
 List and perform various lifecycle tasks
 """
 

--- a/manage_issues.py
+++ b/manage_issues.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+"""This script is used to manage Bugzilla and Jira issues
+List and perform various lifecycle tasks
+"""
+
+import click
+import json
+import logging
+import os
+import requests
+import signal
+import sys
+
+from jira import JIRA
+
+try:
+    import yaml
+except ImportError:
+    import ruamel.yaml as yaml
+
+signal.signal(signal.SIGINT, lambda signum, frame: sys.exit(0))
+
+cfg = yaml.safe_load(open(os.path.join(os.environ["HOME"], ".config", "jira.yml")))
+url = cfg[cfg["current"]]["url"]
+token = cfg[cfg["current"]]["token"]
+
+# jira = JIRA(url, token_auth=token, get_server_info=False, options={"rest_api_version": "3"})
+jira = JIRA(url, token_auth=token)
+
+# key is project
+# value is dict
+#   key is name or id - value is id or name corresponding
+ISSUE_TYPES_TO_ID = {}  # key is name or id - value is id
+ISSUE_TYPES_TO_NAME = {}  # key is name or id - value is name
+# key is project
+# value is dict
+#   key is issue type name or id
+#   value is dict
+#     key is field name or field id
+#     value data about field
+ISSUE_TYPE_FIELDS = {}
+
+
+def __ensure_project_issue_types(project):
+    if project in ISSUE_TYPES_TO_NAME:
+        return
+    for issue_type in jira.project_issue_types(project, maxResults=999):
+        ISSUE_TYPES_TO_ID.setdefault(project, {})[issue_type.name] = issue_type.id
+        ISSUE_TYPES_TO_ID.setdefault(project, {})[issue_type.id] = issue_type.id
+        ISSUE_TYPES_TO_NAME.setdefault(project, {})[issue_type.id] = issue_type.name
+        ISSUE_TYPES_TO_NAME.setdefault(project, {})[issue_type.name] = issue_type.name
+
+
+def __ensure_project_issue_fields(project, issue_type):
+    __ensure_project_issue_types(project)
+    if project in ISSUE_TYPE_FIELDS and issue_type in ISSUE_TYPE_FIELDS[project]:
+        return
+    issue_type_id = ISSUE_TYPES_TO_ID[project][issue_type]
+    for field in jira.project_issue_fields(project, issue_type_id, maxResults=999):
+        rec = field.raw
+        for name in ("items", "custom", "system"):
+            if not rec["schema"].get(name):
+                rec["schema"][name] = None
+        rec["project"] = project
+        rec["issue_type"] = ISSUE_TYPES_TO_NAME[project][issue_type]
+        rec["is_create_field"] = True
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(rec["issue_type"], {})[
+            field.name
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(rec["issue_type"], {})[
+            field.fieldId
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type_id, {})[
+            field.name
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type_id, {})[
+            field.fieldId
+        ] = rec
+
+
+def __update_issue_type_fields(issue):
+    project = issue.get_field("project").key
+    issue_type = issue.get_field("issuetype").name
+    __ensure_project_issue_fields(project, issue_type)
+    issue_type_id = ISSUE_TYPES_TO_ID[project][issue_type]
+    for field_id, rec in jira.editmeta(issue.key)["fields"].items():
+        field_data = (
+            ISSUE_TYPE_FIELDS.get(project, {}).get(issue_type, {}).get(field_id)
+        )
+        if field_data:
+            logging.debug(
+                "field [%s] already exists for project [%s] type [%s]",
+                field_id,
+                project,
+                issue_type,
+            )
+            continue  # do not replace/overwrite existing fields
+        for name in ("items", "custom", "system"):
+            if not rec["schema"].get(name):
+                rec["schema"][name] = None
+        rec["project"] = project
+        rec["issue_type"] = ISSUE_TYPES_TO_NAME[project][issue_type]
+        rec["is_create_field"] = False
+        field_name = rec["name"]
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type, {})[
+            field_name
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type, {})[
+            field_id
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type_id, {})[
+            field_name
+        ] = rec
+        ISSUE_TYPE_FIELDS.setdefault(project, {}).setdefault(issue_type_id, {})[
+            field_id
+        ] = rec
+
+
+def get_github_issue_pr(ctx):
+    response = requests.get(ctx["github_url_api"])
+    rv = response.json()
+    rv["is_pull"] = "pull_request" in rv
+    if rv["is_pull"]:
+        response = requests.get(ctx["github_url_api_pr_merge"])
+        rv["is_merged"] = response.status_code == 204
+    else:
+        rv["is_merged"] = False
+    return rv
+
+
+def get_update_value(project, issue_type, field_name_or_id, value, is_create):
+    """Given a project, a field name or id, and a value, and a flag to indicate
+    if this is for a create operation or an edit operation, return the value in
+    the correct format for a create or edit operation."""
+    __ensure_project_issue_fields(project, issue_type)
+    field_data = ISSUE_TYPE_FIELDS[project][issue_type].get(field_name_or_id)
+    if not field_data:
+        return None  # possibly an edit only field?
+    if field_data["is_create_field"] != is_create:
+        return None  # field is not for this operation
+    schema = field_data["schema"]
+    if schema["type"] == "int":
+        rv = int(value)
+    elif schema["type"] == "number":
+        rv = float(value)
+    elif schema["type"] == "string" or schema["type"] == "any":
+        rv = str(value)
+    elif schema["type"] == "option":
+        rv = {"value": str(value)}
+    elif schema["type"] == "array":
+        if isinstance(value, list):
+            rv = value
+        elif isinstance(value, tuple):
+            rv = list(value)  # convert to list
+        elif schema["items"] == "int":
+            rv = [int(value)]
+        elif schema["items"] == "number":
+            rv = [float(value)]
+        elif schema["items"] == "string" or schema["type"] == "any":
+            rv = [str(value)]
+        elif schema["items"] == "option":
+            rv = [{"value": str(value)}]
+        elif schema["system"]:
+            rv = [{"name": str(value)}]
+    elif schema["system"]:
+        rv = {"name": str(value)}
+    return {field_data["fieldId"]: rv}
+
+
+def set_itm_dtm(args):
+    """Set ITM and DTM fields to given values."""
+    if args.itm is None and args.dtm is None:
+        return
+    iter = ((args.itm_issue_field, args.itm), (args.dtm_issue_field, args.dtm))
+    query = f"component = {args.component} AND '{args.itr_query_field}' = rhel-{args.itr} AND {args.status_query_field} = '{args.status}'"
+    issues = jira.search_issues(
+        query, fields=[args.itm_query_field, args.dtm_query_field]
+    )
+    if args.debug:
+        print(issues)
+    for issue in issues:
+        for issue_field, val in iter:
+            if val is None:
+                continue
+            try:
+                cur_val = int(issue.get_field(issue_field).value)
+            except (ValueError, AttributeError):
+                cur_val = 0
+            update = {}
+            if val == "None":
+                # reset
+                update = {issue_field: None}
+            elif cur_val < int(val):
+                update = {issue_field: {"value": val}}
+            else:
+                continue
+            issue.update(update)
+            if args.debug:
+                print(issue)
+
+
+def __update_jira_issue(issue, fields):
+    __update_issue_type_fields(issue)
+    project = issue.get_field("project").key
+    issue_type = issue.get_field("issuetype").name
+    update_fields = {}
+    for field_name, field_value in fields.items():
+        # look for an update-only field first
+        update_item = get_update_value(
+            project, issue_type, field_name, field_value, False
+        )
+        if not update_item:
+            # create fields can also be updated
+            update_item = get_update_value(
+                project, issue_type, field_name, field_value, True
+            )
+        update_fields.update(update_item)
+    issue.update(fields=update_fields)
+    return issue
+
+
+def __create_jira_issue(fields):
+    issue_type = fields.pop("issuetype")
+    project = fields.pop("project")
+    __ensure_project_issue_fields(project, issue_type)
+    create_fields = {"project": project, "issuetype": issue_type}
+    update_fields = (
+        {}
+    )  # these cannot be passed in the create op, so update after create
+    for field_name, field_value in fields.items():
+        update_value = get_update_value(
+            project, issue_type, field_name, field_value, True
+        )
+        if update_value:
+            create_fields.update(update_value)
+        else:
+            update_fields[field_name] = field_value  # candidate for update
+    issue = jira.create_issue(fields=create_fields)
+    if update_fields:
+        issue = __update_jira_issue(issue, update_fields)
+    return issue
+
+
+def __github_to_args(ctx):
+    """Update fields in args with given github_url."""
+    ary = ctx["github_url"].split("/")
+    ctx["github_url_api"] = (
+        "https://api.github.com/repos/" + ary[3] + "/" + ary[4] + "/issues/" + ary[-1]
+    )
+    ctx["github_url_api_pr_merge"] = (
+        "https://api.github.com/repos/"
+        + ary[3]
+        + "/"
+        + ary[4]
+        + "/pulls/"
+        + ary[-1]
+        + "/merge"
+    )
+    gh_issue = get_github_issue_pr(ctx)
+    if not ctx["summary"]:
+        ctx["summary"] = gh_issue["title"]
+    if not ctx["description"]:
+        ctx["description"] = gh_issue["body"].replace("\r", "")
+    if not ctx["issue_type"]:
+        if ctx["summary"].startswith("feat: "):
+            ctx["issue_type"] = "Story"
+        elif ctx["summary"].startswith("fix: "):
+            ctx["issue_type"] = "Bug"
+        else:
+            ctx["issue_type"] = "Bug"  # user should give ctx["issue_type"] in this case
+    if not ctx["role"]:
+        ary = ctx["github_url"].split("/")
+        if ary[3] == "linux-system-roles":
+            ctx["role"] = [ary[4]]
+        elif ary[3] == "willshersystems" and ary[4] == "ansible-sshd":
+            ctx["role"] = ["sshd"]
+        elif ary[3] == "performancecopilot" and ary[4] == "ansible-pcp":
+            ctx["role"] = ["metrics"]
+        else:
+            raise Exception("unknown url " + ctx["github_url"])
+    if not ctx["status"]:
+        if gh_issue["is_merged"]:
+            ctx["status"] = "In Progress"
+        else:
+            ctx["status"] = "Planning"
+    if not ctx["dev_ack"]:
+        if gh_issue["is_pull"]:
+            ctx["dev_ack"] = "Dev ack"
+    if not ctx["doc_text_type"]:
+        if ctx["issue_type"] == "Story":
+            ctx["doc_text_type"] = "Enhancement"
+        elif ctx["issue_type"] == "Bug":
+            ctx["doc_text_type"] = "Bug Fix"
+    if not ctx["doc_text"]:
+        if gh_issue["is_pull"]:
+            ctx["doc_text"] = ctx["description"]
+    if not ctx["docs_impact"]:
+        if ctx["doc_text_type"]:
+            ctx["docs_impact"] = "Yes"
+        else:
+            ctx["docs_impact"] = "No"
+
+
+# these are all fields that can use the string format method
+# to construct the final value from variables derived from
+# previous issues
+TEMPLATE_FIELDS = ["description", "epic_name", "summary"]
+
+
+# this handles creating the jira issue, updating it,
+# doing the status transition, adding links, etc.
+def __create_issue(kwargs):
+    remote_link_data = {}
+    if kwargs["github_url"]:
+        # update missing args with fields from given github issue/pr
+        __github_to_args(kwargs)
+        remote_link_data = {
+            "url": kwargs["github_url"],
+            "title": "link to github issue",
+        }
+    if kwargs["project"] == "RHEL" and not kwargs["component"]:
+        kwargs["component"] = "rhel-system-roles"
+    if kwargs["issue_type"] == "Epic":
+        if not kwargs["epic_name"]:
+            kwargs["epic_name"] = kwargs["summary"]
+        elif not kwargs["summary"]:
+            kwargs["summary"] = kwargs["epic_name"]
+    if not kwargs.get("issue_summary"):
+        kwargs["issue_summary"] = kwargs["summary"]
+    else:
+        for field in TEMPLATE_FIELDS:
+            if kwargs[field]:
+                kwargs[field] = kwargs[field].format(
+                    issue_summary=kwargs["issue_summary"]
+                )
+    # convert args to jira create/update fields
+    fields = {}
+    for arg_field, jira_field in ARGS_TO_JIRA_FIELDS.items():
+        val = kwargs[arg_field]
+        if val:
+            fields[jira_field] = val
+    if kwargs["label"]:
+        fields["labels"] = list(kwargs["label"])  # is a list
+    if kwargs["role"]:
+        val = ["system_role_" + ii for ii in kwargs["role"]]
+        if "labels" in fields:
+            fields["labels"].extend(val)
+        else:
+            fields["labels"] = val
+
+    issue = __create_jira_issue(fields)
+    if kwargs["status"]:
+        jira.transition_issue(issue, kwargs["status"])
+    if remote_link_data:
+        jira.add_simple_link(issue.key, remote_link_data)
+    return issue
+
+
+# does not work
+def createmeta(args):
+    print(jira.createmeta(projectKeys=args.project, issuetypeNames=args.issue_type))
+
+
+def editmeta(args):
+    json.dump(jira.editmeta(args.params[0])["fields"], sys.stdout, indent=2)
+
+
+def project_issue_types(args):
+    __ensure_project_issue_types(args.project)
+    json.dump(ISSUE_TYPES_TO_NAME[args.project], sys.stdout, indent=2)
+    print("")
+
+
+def project_issue_fields(args):
+    __ensure_project_issue_types(args.project)
+    for issue_type in ISSUE_TYPES_TO_ID[args.project].keys():
+        try:
+            if int(issue_type):
+                __ensure_project_issue_fields(args.project, issue_type)
+                print(
+                    "Project",
+                    args.project,
+                    "issue_type",
+                    ISSUE_TYPES_TO_NAME[args.project][issue_type],
+                )
+                json.dump(
+                    ISSUE_TYPE_FIELDS[args.project][issue_type], sys.stdout, indent=2
+                )
+                print("")
+        except ValueError:
+            pass
+
+
+def dump(args):
+    """Dump an issue."""
+    for issue_id in args.params:
+        issue = jira.issue(issue_id)
+        json.dump(issue.raw, sys.stdout, indent=2)
+
+
+# for simple fields, map the name used when giving
+# an argument to the name used with the Jira api
+# fields not listed here require special handling
+# or a different api (e.g. status is a transition)
+ARGS_TO_JIRA_FIELDS = {
+    "project": "project",
+    "issue_type": "issuetype",
+    "summary": "summary",
+    "epic_name": "Epic Name",
+    "description": "description",
+    "component": "components",
+    "version": "fixVersions",
+    "itm": "Internal Target Milestone",
+    "dtm": "Dev Target Milestone",
+    "dev_ack": "ACKs Check",
+    "story_points": "Story Points",
+    "sprint": "Sprint",
+    "doc_text_type": "Release Note Type",
+    "doc_text": "Release Note Text",
+    "docs_impact": "Product Documentation Required",
+    "product": "Products",
+}
+
+create_issues = []
+
+
+@click.command()
+@click.option("--component", type=str, help="component")
+@click.option(
+    "--github-url",
+    type=str,
+    help="https url of github issue or pr used to create or update jira issue",
+)
+@click.option(
+    "--version",
+    type=str,
+    help="Internal Target Release e.g. rhel-9.6",
+)
+@click.option(
+    "--itm",
+    type=int,
+    help="Internal Target Milestone",
+)
+@click.option(
+    "--dtm",
+    type=int,
+    help="Dev Target Milestone",
+)
+@click.option(
+    "--dev-ack",
+    type=str,
+    help="Give dev ack",
+)
+@click.option(
+    "--status",
+    type=str,
+    help="issue status",
+)
+@click.option(
+    "--project",
+    type=str,
+    required=True,
+    help="Project for issues",
+)
+@click.option(
+    "--issue-type",
+    type=click.Choice(["Bug", "Story", "Task", "Epic"], case_sensitive=False),
+    help="Type of issue",
+)
+@click.option(
+    "--summary",
+    type=str,
+    help="Issue summary - short title for issue",
+)
+@click.option(
+    "--epic-name",
+    type=str,
+    help="Epic name - required for epics",
+)
+@click.option(
+    "--description",
+    type=str,
+    help="Issue description - long, multiline information about issue",
+)
+@click.option(
+    "--role",
+    multiple=True,
+    help="One or more role names",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Turn on debug logging.",
+)
+@click.option(
+    "--doc-text-type",
+    type=str,
+    help="release note type",
+)
+@click.option(
+    "--doc-text",
+    type=str,
+    help="release note text",
+)
+@click.option(
+    "--docs-impact",
+    type=str,
+    help="will docs be impacted, yes or no",
+)
+@click.option(
+    "--story-points",
+    type=float,
+    help="story points",
+)
+@click.option(
+    "--sprint",
+    type=str,
+    help="sprint",
+)
+@click.option(
+    "--label",
+    multiple=True,
+    help="labels",
+)
+@click.option(
+    "--product",
+    type=str,
+    help="product",
+)
+def create_issue(**kwargs):
+    """Create an issue."""
+    # just append the arguments to the list, so we can process instances
+    # where there are multiple issues and an epic
+    create_issues.append(kwargs)
+
+
+@click.group(chain=True)
+@click.option("--debug", is_flag=True)
+def cli(debug):
+    if debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+
+cli.add_command(create_issue)
+
+
+def main():
+    try:
+        cli(auto_envvar_prefix="LSR")
+    except SystemExit as se:
+        if se.code != 0:
+            raise se
+    issues = []
+    epic = None
+    issue_summary = None
+    for data in create_issues:
+        data["issue_summary"] = issue_summary
+        issue = __create_issue(data)
+        issue_summary = data["issue_summary"]
+        if data.get("issue_type", "").lower() == "epic":
+            epic = issue
+        else:
+            issues.append(issue)
+    if epic:
+        jira.add_issues_to_epic(epic.id, [issue.key for issue in issues])
+    for issue in issues:
+        print(issue.permalink(), issue.get_field("summary"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manage_issues.py
+++ b/manage_issues.py
@@ -193,7 +193,12 @@ def __update_jira_issue(issue, fields):
                 project, issue_type, field_name, field_value, True
             )
         if not update_item:
-            logging.info("Field [%s] could not be found for project [%s] type [%s]", field_name, project, issue_type)
+            logging.info(
+                "Field [%s] could not be found for project [%s] type [%s]",
+                field_name,
+                project,
+                issue_type,
+            )
         else:
             update_fields.update(update_item)
     if update_fields:
@@ -375,6 +380,7 @@ def project_issue_fields(args):
                 print("")
         except ValueError:
             pass
+
 
 @click.command()
 @click.argument("keys", nargs=-1)
@@ -613,7 +619,9 @@ create_issues = []
 )
 @click.option(
     "--severity",
-    type=click.Choice(["Critical", "Important", "Moderate", "Low"], case_sensitive=False),
+    type=click.Choice(
+        ["Critical", "Important", "Moderate", "Low"], case_sensitive=False
+    ),
     default="Low",
     help="Severity of issue",
 )
@@ -639,7 +647,15 @@ create_issues = []
 )
 @click.option(
     "--doc-text-type",
-    type=click.Choice(["Bug Fix", "CVE - Common Vulnerabilities and Exposures", "Enhancement", "Release Note Not Required"], case_sensitive=False),
+    type=click.Choice(
+        [
+            "Bug Fix",
+            "CVE - Common Vulnerabilities and Exposures",
+            "Enhancement",
+            "Release Note Not Required",
+        ],
+        case_sensitive=False,
+    ),
     help="release note type",
 )
 @click.option(
@@ -697,13 +713,14 @@ cli.add_command(create_issue)
 cli.add_command(dump_issue)
 cli.add_command(rpm_release)
 
+
 def __update_data_from_base_issue(base_issue, data):
     data["issue_summary"] = base_issue.get_field("summary")
     for label in base_issue.get_field("labels"):
         if label.startswith("system_role_"):
             if not isinstance(data["label"], list):
                 data["label"] = list(data["label"])
-            if not label in data["label"]:
+            if label not in data["label"]:
                 data["label"].append(label)
     # update links to include github link, if any
     if not data.get("remote_link_data"):
@@ -731,7 +748,7 @@ def main():
         if base_issue_key:
             base_issue = jira.issue(base_issue_key)
             __update_data_from_base_issue(base_issue, data)
-            if not base_issue_key in issue_keys:
+            if base_issue_key not in issue_keys:
                 issue_keys.add(base_issue_key)
                 issues.append(base_issue)
         issue = __create_issue(data)

--- a/manage_issues.py
+++ b/manage_issues.py
@@ -175,7 +175,10 @@ def set_itm_dtm(args):
     if args.itm is None and args.dtm is None:
         return
     iter = ((args.itm_issue_field, args.itm), (args.dtm_issue_field, args.dtm))
-    query = f"component = {args.component} AND '{args.itr_query_field}' = rhel-{args.itr} AND {args.status_query_field} = '{args.status}'"
+    query = (
+        f"component = {args.component} AND '{args.itr_query_field}' = rhel-{args.itr}"
+        f"AND {args.status_query_field} = '{args.status}'"
+    )
     issues = jira.search_issues(
         query, fields=[args.itm_query_field, args.dtm_query_field]
     )


### PR DESCRIPTION
This version of manage_issues.py allows creation of multiple issues and
epics at the same time, and links the created issues to the created
epic.  It also allows creation of issues from github issues and PRs,
similar to manage-issues.sh.  There is still plenty of missing
functionality of manage-issues.sh.
