### PR TITLE
Change source path to the actual role folder

### DIFF
--- a/release_collection.py
+++ b/release_collection.py
@@ -409,7 +409,7 @@ def role_to_collection(
         "--role",
         rolename,
         "--src-path",
-        args.src_path,
+        os.path.join(args.src_path, rolename),
         "--dest-path",
         args.dest_path,
         "--namespace",


### PR DESCRIPTION
Prevent issues when checking out multiple remote roles.

Fix for #357 