### PR TITLE
allow role-make-version-changelog.sh to be used without managed-role-repos.sh

### DIFF
--- a/manage-role-repos.sh
+++ b/manage-role-repos.sh
@@ -115,6 +115,9 @@ if ! tty -s; then
     stdincmds="$(cat)"
 fi
 
+# tell script called from this script that it was called from manage-role-repos.sh
+CALLED_FROM_MANAGE_ROLE_REPOS=true
+export CALLED_FROM_MANAGE_ROLE_REPOS
 for repo in $repos; do
     if [ -n "${EXARRAY[$repo]:-}" ]; then
         continue


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enable the version changelog script to operate independently by adding default organization resolution and context-aware branch handling, while maintaining compatibility when called from manage-role-repos.sh.

New Features:
- Enable standalone execution of role-make-version-changelog.sh without manage-role-repos.sh

Enhancements:
- Default origin_org and upstream_org to the repository owner when unset
- Introduce CALLED_FROM_MANAGE_ROLE_REPOS flag to conditionally adjust clone, checkout, and directory logic
- Preserve the current git branch and fallback branch naming convention when running standalone

Chores:
- Export CALLED_FROM_MANAGE_ROLE_REPOS in manage-role-repos.sh to signal invocation context