### PR TITLE
fix: state:open state:closed doesn't work anymore, use --state all

### DIFF
--- a/get-github-stats.sh
+++ b/get-github-stats.sh
@@ -58,14 +58,16 @@ user_is_maintainer() {
 # get PRs
 get_prs() {
     gh pr list -R "$upstream_org/$repo" \
-      -S "created:$DATE_RANGE state:open state:closed" \
+      -S "created:$DATE_RANGE" \
+      --state all \
       --json number,author,state,title \
       --jq '.[] | "\(.number) \(.author.login) \(.state) \(.title)"'
 }
 
 get_issues() {
     gh issue list -R "$upstream_org/$repo" \
-      -S "created:$DATE_RANGE state:open state:closed" \
+      -S "created:$DATE_RANGE" \
+      --state all \
       --json number,author,state \
       --jq '.[] | "\(.number) \(.author.login) \(.state)"'
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace combined state filter (state:open state:closed) in GH CLI calls with --state all for both PRs and issues