### PR TITLE
Add hpc

### DIFF
--- a/collection_release.yml
+++ b/collection_release.yml
@@ -32,7 +32,7 @@ nbde_server:
   ref: 1.5.0
   sourcenum: 11
 nbde_client:
-  ref: 1.3.4
+  ref: 1.3.5
   sourcenum: 12
 certificate:
   ref: 1.4.2
@@ -49,13 +49,13 @@ ssh:
   ref: 1.6.1
   sourcenum: 16
 ha_cluster:
-  ref: 1.26.0
+  ref: 1.27.0
   sourcenum: 17
 vpn:
   ref: 1.6.12
   sourcenum: 18
 firewall:
-  ref: 1.11.1
+  ref: 1.11.2
   sourcenum: 19
 cockpit:
   ref: 1.7.1
@@ -88,7 +88,7 @@ bootloader:
   ref: 1.1.4
   sourcenum: 29
 snapshot:
-  ref: 1.5.2
+  ref: 1.6.0
   sourcenum: 30
 gfs2:
   ref: 1.0.3
@@ -100,5 +100,5 @@ aide:
   ref: 1.2.1
   sourcenum: 33
 hpc:
-  ref: null
+  ref: 0.3.0
   sourcenum: 34

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: "fedora"
 name: "linux_system_roles"
-version: "1.110.1"
+version: "1.111.0"
 description: "Ansible roles for linux system components management"
 
 authors:

--- a/lsr_role2collection/COLLECTION_CHANGELOG.md
+++ b/lsr_role2collection/COLLECTION_CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+[1.111.0] - 2025-11-13
+---------------------
+
+### New Features
+
+- ha_cluster - feat: export cluster constraints (#326)
+- hpc - New Role
+- snapshot - feat: add support for "bootable" snapshots (#115)
+
+### Bug Fixes
+
+- firewall - fix: install python311-firewall on SLES 15 (#300)
+- nbde_client - fix: idempotence issue when binding fails to be added (#196)
+
 [1.110.1] - 2025-10-23
 ---------------------
 


### PR DESCRIPTION
## Summary by Sourcery

Release version 1.111.0: introduce the new hpc role, add features to ha_cluster and snapshot roles, apply bug fixes to firewall and nbde_client, and update role references and collection metadata accordingly

New Features:
- Add new hpc role to the collection
- Export cluster constraints in ha_cluster role
- Add support for bootable snapshots in snapshot role

Bug Fixes:
- Install python311-firewall on SLES 15 in firewall role
- Fix idempotence issue in nbde_client when binding addition fails

Enhancements:
- Bump nbde_client to 1.3.5, ha_cluster to 1.27.0, firewall to 1.11.2, and snapshot to 1.6.0 in collection_release.yml
- Update collection version to 1.111.0 in galaxy.yml