### PR TITLE
remove the hpc role - will be moved into a separate collection

### DIFF
--- a/collection_release.yml
+++ b/collection_release.yml
@@ -99,6 +99,3 @@ sudo:
 aide:
   ref: 1.2.2
   sourcenum: 33
-hpc:
-  ref: 0.3.1
-  sourcenum: 34


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the hpc role entry from collection_release.yml so it is no longer part of this collection's release metadata.