### PR TITLE
fix: manage repos - only fetch origin and upstream

### DIFF
--- a/manage-role-repos.sh
+++ b/manage-role-repos.sh
@@ -93,7 +93,11 @@ clone_repo() {
             fi
         fi
     fi
-    git fetch --all --quiet
+    for remote in $(git remote); do
+        if [ "$remote" = "upstream" ] || [ "$remote" = "origin" ]; then
+            git fetch "$remote" --quiet
+        fi
+    done
 }
 
 repos=${REPOS:-$(gh repo list "$LSR_GH_ORG" -L 100 --json name -q '.[].name')}


### PR DESCRIPTION
Only fetch origin and upstream repos

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Restrict git fetch in manage-role-repos to the origin and upstream remotes instead of fetching all remotes.