### PR TITLE
fix: meta runtime.yml requires_ansible 2.16.0 or later

### DIFF
--- a/lsr_role2collection/runtime.yml
+++ b/lsr_role2collection/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"


### PR DESCRIPTION
Ansible partner team says to bump this to 2.16.0 or later

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Build:
- Update runtime.yml to require Ansible >= 2.16.0 instead of >= 2.15.0.