### PR TITLE
add trustee_client, trustee_server, auditd - allow mainid to be updated

### DIFF
--- a/collection_release.yml
+++ b/collection_release.yml
@@ -1,3 +1,6 @@
+mainid:
+  ref: 1.123.0
+  sourcenum: 0
 postfix:
   ref: 1.7.0
   sourcenum: 1
@@ -99,3 +102,12 @@ sudo:
 aide:
   ref: 1.3.0
   sourcenum: 33
+trustee_client:
+  ref: null
+  sourcenum: 34
+trustee_server:
+  ref: null
+  sourcenum: 35
+auditd:
+  ref: null
+  sourcenum: 36

--- a/generate_spec_sources.py
+++ b/generate_spec_sources.py
@@ -84,6 +84,8 @@ def generate_sources(output):
     k.sort()
 
     for i in k:
+        if i == 0:
+            continue
         r = rolesbysourcenum[i]
         org = roles[r].get("org")
         repo = roles[r].get("repo")
@@ -100,11 +102,14 @@ def generate_sources(output):
         else:
             output.write(f"%deftag {i} {ref}\n\n")
     for i in k:
+        if i == 0:
+            continue
         output.write(f"Source{i}: %{{archiveurl{i}}}\n")
 
 
 def generate_setup(output):
-    k = list(rolesbysourcenum.keys())
+    # omit mainid - sourcenum 0
+    k = list([ii for ii in rolesbysourcenum.keys() if ii != 0])
     k.sort()
 
     output.write(
@@ -120,7 +125,6 @@ with open(COLLECTION_RELEASE, "r") as cf:
         roleinfo["sourcenum"]: rolename for rolename, roleinfo in roles.items()
     }
 
-
 sources_replacement = Replacement(
     BEGIN_SOURCES_MARKER, END_SOURCES_MARKER, generate_sources
 )
@@ -129,15 +133,20 @@ setup_replacement = Replacement(BEGIN_SETUP_MARKER, END_SETUP_MARKER, generate_s
 f = open(SPECFILE_IN, "r")
 of = open(SPECFILE_OUT, "w")
 
+mainid_info = rolesbysourcenum.get(0)
+
 for line in f:
-    changed_sources, new_line = sources_replacement.process_line(line)
-    changed_setup, new_new_line = setup_replacement.process_line(new_line)
-    if changed_sources and changed_setup:
-        sys.exit(
-            "Begin marker {} in the output of sources replacement".format(
-                setup_replacement.begin_marker
+    if line.startswith("%global mainid ") and mainid_info:
+        new_new_line = "%global mainid " + mainid_info["ref"]
+    else:
+        changed_sources, new_line = sources_replacement.process_line(line)
+        changed_setup, new_new_line = setup_replacement.process_line(new_line)
+        if changed_sources and changed_setup:
+            sys.exit(
+                "Begin marker {} in the output of sources replacement".format(
+                    setup_replacement.begin_marker
+                )
             )
-        )
     of.write(new_new_line)
 
 for i in (sources_replacement, setup_replacement):

--- a/release_collection.py
+++ b/release_collection.py
@@ -624,6 +624,8 @@ def update_collection(args, galaxy, coll_rel):
     # major, minor, micro, hash
     versions_updated = [False, False, False, False]
     for rolename in args.include:
+        if rolename == "mainid":
+            continue
         if not args.skip_git:
             if args.use_commit_hash and rolename not in args.use_commit_hash_role:
                 args.use_commit_hash_role.append(rolename)
@@ -718,6 +720,13 @@ def update_collection(args, galaxy, coll_rel):
             return
         update_galaxy_version(args, galaxy, versions_updated)
         if not args.no_update:
+            if "mainid" in coll_rel:
+                coll_rel["mainid"]["ref"] = galaxy["version"]
+            else:
+                coll_rel["mainid"] = {
+                    "ref": galaxy["version"],
+                    "sourcenum": 0,
+                }
             with open(args.collection_release_yml.name, "w") as crf:
                 yaml.safe_dump(coll_rel, crf, sort_keys=False)
 


### PR DESCRIPTION
new roles - trustee_client, trustee_server, auditd

allow mainid to be updated - use sourcenum 0 for mainid (auto-maintenance)
it isn't a real role but we want to be able to update the mainid version
in the packit/fedora automation

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Allow the mainid source to be treated as an auto-maintained entry while adding new trustee and auditd roles to the collection.

New Features:
- Add mainid entry with sourcenum 0 to collection_release to represent the main collection ID.
- Introduce new trustee_client, trustee_server, and auditd roles with assigned source numbers in the collection metadata.

Enhancements:
- Skip sourcenum 0 when generating standard source tags and setup macros while handling mainid separately in spec generation.
- Automatically update the mainid ref in collection_release.yml to track the galaxy collection version during updates.