### PR TITLE
fix generate_spec_sources.py

### DIFF
--- a/generate_spec_sources.py
+++ b/generate_spec_sources.py
@@ -133,7 +133,7 @@ setup_replacement = Replacement(BEGIN_SETUP_MARKER, END_SETUP_MARKER, generate_s
 f = open(SPECFILE_IN, "r")
 of = open(SPECFILE_OUT, "w")
 
-mainid_info = rolesbysourcenum.get(0)
+mainid_info = roles.get("mainid")
 
 for line in f:
     if line.startswith("%global mainid ") and mainid_info:


### PR DESCRIPTION
fix generate_spec_sources.py

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Fix main package identifier resolution in generate_spec_sources.py to use the named role entry rather than the source index mapping.