### PR TITLE
Add information about collection requirement older versions

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -765,7 +765,9 @@ def get_beaker_job_info(args, job):
             xml_data = open(job).read()
         bs = BeautifulSoup(xml_data, "xml")
     else:  # assume it is a job number like J:1213552
-        result = subprocess.run(["bkr", "job-results", job], capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            ["bkr", "job-results", job], capture_output=True, text=True, check=True
+        )
         bs = BeautifulSoup(result.stdout, "xml")
     data = {}
     data["job"] = job

--- a/release_collection.py
+++ b/release_collection.py
@@ -513,7 +513,15 @@ def create_collection_extra_files(args, coll_dir, galaxy=None):
             ee_dependencies.append("system: bindep.txt")
         if galaxy["dependencies"]:
             with open(collection_req_yml_dest, "w") as crf:
-                crf.write("---\ncollections:\n")
+                crf.write(
+                    "---\n"
+                    "# fedora.linux_system_roles still supports EL7, which limits dependency collection versions.\n"
+                    "# Ansible allows only one version per dependency; you cannot pin different versions\n"
+                    "# for different managed hosts.\n"
+                    "# If you do not need to manage EL7 hosts, you may force-install dependencies at the\n"
+                    "# latest versions instead of the ones listed below.\n"
+                    "collections:\n"
+                )
                 for k in galaxy["dependencies"].keys():
                     crf.write("  - name: {0}\n".format(k))
             ee_dependencies.append("galaxy: requirements.yml")


### PR DESCRIPTION
In collection-requirements.yml in the built fedora.linux_system_roles collection, add comment that users can use latest collections if they don't need to support EL7.

Fixes https://github.com/linux-system-roles/linux-system-roles.github.io/issues/137

Related Jira: RHELMISC-34455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced generated requirements guidance with explanatory comments clarifying EL7/collection dependency version limitations, so users receive clearer compatibility and installation guidance when inspecting requirement manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->