### PR TITLE
Switch to packaging.version for version parsing

### DIFF
--- a/release_collection.py
+++ b/release_collection.py
@@ -29,7 +29,10 @@ except ImportError:
 
 import json
 
-from pkg_resources import parse_version
+try:
+    from packaging.version import parse as parse_version
+except ImportError:
+    from pkg_resources import parse_version
 
 try:
     import markdown


### PR DESCRIPTION
`pkg_resources` was dropped from setuptools 82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version parsing reliability by using a more modern parser first and automatically falling back to an alternative when needed.
  * Helps ensure version comparisons work more consistently across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->