### PR TITLE
publish_collection: prune old collection versions from Galaxy

### DIFF
--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -77,6 +77,7 @@ jobs:
           echo "updated=1" >> $GITHUB_OUTPUT
 
       - name: Keep latest 20 versions in Galaxy
+        if: ${{ steps.build.outputs.updated == 1 }}
         shell: bash
         run: |
           set -euxo pipefail

--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -76,6 +76,14 @@ jobs:
           echo "tagname=$NEWVER" >> $GITHUB_OUTPUT
           echo "updated=1" >> $GITHUB_OUTPUT
 
+      - name: Keep latest 20 versions in Galaxy
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 ./remove_old_galaxy_versions.py --keep 20
+        env:
+          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+
       - name: Create tag
         if: ${{ steps.build.outputs.updated == 1 }}
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2

--- a/remove_old_galaxy_versions.py
+++ b/remove_old_galaxy_versions.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python3
+"""Remove old versions of a collection from Ansible Galaxy.
+
+Keeps the newest N versions (by semantic version) and deletes the rest using
+the Galaxy v3 REST API. Authentication uses a Galaxy API token.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+from packaging.version import InvalidVersion, Version
+
+DEFAULT_SERVER = "https://galaxy.ansible.com"
+LIST_PATH = (
+    "/api/v3/plugin/ansible/content/published/collections/index/"
+    "{namespace}/{name}/versions/"
+)
+
+
+def api_request(url, token, method="GET"):
+    """Perform an authenticated request against the Galaxy API."""
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", "Token " + token)
+    req.add_header("Accept", "application/json")
+    with urllib.request.urlopen(req) as resp:
+        body = resp.read().decode("utf-8")
+        return resp.status, body
+
+
+def list_versions(server, token, namespace, name):
+    """Return a list of all version strings for the collection."""
+    versions = []
+    path = LIST_PATH.format(namespace=namespace, name=name) + "?limit=100&offset=0"
+    while path:
+        _, body = api_request(server + path, token)
+        data = json.loads(body)
+        versions.extend(item["version"] for item in data["data"])
+        path = data.get("links", {}).get("next")
+    return versions
+
+
+def sort_versions(versions):
+    """Sort version strings newest-first, tolerating non-PEP440 versions."""
+
+    def key(ver):
+        try:
+            return (1, Version(ver))
+        except InvalidVersion:
+            return (0, Version("0"))
+
+    # Non-parseable versions sort last (oldest) so they are pruned first.
+    return sorted(versions, key=key, reverse=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--namespace", default="fedora")
+    parser.add_argument("--name", default="linux_system_roles")
+    parser.add_argument("--server", default=DEFAULT_SERVER)
+    parser.add_argument(
+        "--keep",
+        type=int,
+        default=20,
+        help="Number of newest versions to keep (default: 20)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GALAXY_API_KEY"),
+        help="Galaxy API token (default: $GALAXY_API_KEY)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print which versions would be deleted",
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        sys.exit("No Galaxy token provided (use --token or $GALAXY_API_KEY)")
+
+    versions = sort_versions(list_versions(args.server, args.token, args.namespace, args.name))
+    print("Found %d versions of %s.%s" % (len(versions), args.namespace, args.name))
+
+    to_delete = versions[args.keep :]
+    if not to_delete:
+        print("Nothing to delete - %d versions <= keep limit %d" % (len(versions), args.keep))
+        return
+
+    print("Keeping newest %d, deleting %d older versions" % (args.keep, len(to_delete)))
+    base = args.server + LIST_PATH.format(namespace=args.namespace, name=args.name)
+    for version in to_delete:
+        url = base + version + "/"
+        if args.dry_run:
+            print("Would delete %s" % version)
+            continue
+        try:
+            status, _ = api_request(url, args.token, method="DELETE")
+            print("Deleted %s (status %s)" % (version, status))
+        except urllib.error.HTTPError as err:
+            print("Failed to delete %s: %s %s" % (version, err.code, err.reason))
+
+
+if __name__ == "__main__":
+    main()

--- a/remove_old_galaxy_versions.py
+++ b/remove_old_galaxy_versions.py
@@ -15,6 +15,7 @@ import urllib.request
 from packaging.version import InvalidVersion, Version
 
 DEFAULT_SERVER = "https://galaxy.ansible.com"
+REQUEST_TIMEOUT = 30
 LIST_PATH = (
     "/api/v3/plugin/ansible/content/published/collections/index/"
     "{namespace}/{name}/versions/"
@@ -26,7 +27,7 @@ def api_request(url, token, method="GET"):
     req = urllib.request.Request(url, method=method)
     req.add_header("Authorization", "Token " + token)
     req.add_header("Accept", "application/json")
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
         body = resp.read().decode("utf-8")
         return resp.status, body
 
@@ -82,16 +83,25 @@ def main():
     if not args.token:
         sys.exit("No Galaxy token provided (use --token or $GALAXY_API_KEY)")
 
-    versions = sort_versions(list_versions(args.server, args.token, args.namespace, args.name))
+    keep = args.keep
+    if keep < 1:
+        sys.exit("--keep must be at least 1")
+
+    versions = sort_versions(
+        list_versions(args.server, args.token, args.namespace, args.name)
+    )
     print("Found %d versions of %s.%s" % (len(versions), args.namespace, args.name))
 
-    to_delete = versions[args.keep :]
+    to_delete = versions[keep:]
     if not to_delete:
-        print("Nothing to delete - %d versions <= keep limit %d" % (len(versions), args.keep))
+        print(
+            "Nothing to delete - %d versions <= keep limit %d" % (len(versions), keep)
+        )
         return
 
-    print("Keeping newest %d, deleting %d older versions" % (args.keep, len(to_delete)))
+    print("Keeping newest %d, deleting %d older versions" % (keep, len(to_delete)))
     base = args.server + LIST_PATH.format(namespace=args.namespace, name=args.name)
+    failures = 0
     for version in to_delete:
         url = base + version + "/"
         if args.dry_run:
@@ -100,8 +110,14 @@ def main():
         try:
             status, _ = api_request(url, args.token, method="DELETE")
             print("Deleted %s (status %s)" % (version, status))
-        except urllib.error.HTTPError as err:
-            print("Failed to delete %s: %s %s" % (version, err.code, err.reason))
+        except urllib.error.URLError as err:
+            code = getattr(err, "code", "")
+            reason = getattr(err, "reason", err)
+            print("Failed to delete %s: %s %s" % (version, code, reason))
+            failures += 1
+
+    if failures:
+        sys.exit("%d version(s) failed to delete" % failures)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add remove_old_galaxy_versions.py to keep only the newest N versions (default 20) of a collection on Ansible Galaxy via the v3 REST API, and wire it into the publish workflow to run after publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated publishing now retains only the 20 newest collection versions in Ansible Galaxy.
  * Added support for listing, sorting, and removing older published versions.
  * Added a dry-run option and safeguards for missing credentials or deletion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->